### PR TITLE
Specifying the java version as 1.7, and reverting the name change of …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@
 def publishParameters(module: String) = Seq(
   organization := "com.alpinenow",
   name := s"$module",
-  version := "1.5-alpha",
+  version := "1.5-alpha-1",
   publishMavenStyle := true,
   pomExtra := <scm>
     <url>git@github.com:AlpineNow/PluginSDK.git</url>
@@ -24,6 +24,7 @@ def publishParameters(module: String) = Seq(
   },
   licenses := Seq("Apache License 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
   scalacOptions in(Compile, doc) ++= Seq("-doc-footer", "Copyright (c) 2015 Alpine Data Labs."),
+  javacOptions in compile ++= Seq("-source", javaSourceVersion, "-target", javaTargetVersion),
   crossPaths := false,
   publishArtifact in Test := true
 )
@@ -35,7 +36,8 @@ def excludeFromAll(items: Seq[ModuleID], group: String, artifact: String) =
 def excludeJavaxServlet(items: Seq[ModuleID]) =
   excludeFromAll(items, "javax.servlet", "servlet-api")
 
-
+lazy val javaSourceVersion = "1.7"
+lazy val javaTargetVersion = "1.7"
 lazy val scalaMajorVersion = "2.10"
 lazy val sparkVersion = "1.5.1"
 

--- a/plugin-test/src/test/scala/com/alpine/plugin/test/mock/OperatorDialogMock.scala
+++ b/plugin-test/src/test/scala/com/alpine/plugin/test/mock/OperatorDialogMock.scala
@@ -6,7 +6,7 @@ import com.alpine.plugin.core.datasource.OperatorDataSourceManager
 import com.alpine.plugin.core.dialog._
 import com.alpine.plugin.core.io.{ColumnDef, IOBase, TabularSchema}
 import com.alpine.plugin.test.mock.OperatorParametersMock
-import com.alpine.plugin.test.utils.OperatorParametersMockUtils
+import com.alpine.plugin.test.utils.ParameterMockUtil
 
 import scala.util.{Success, Try}
 
@@ -133,7 +133,7 @@ class OperatorDialogMock(overrideParams: OperatorParametersMock, input: IOBase,
       case _ => defaultSelections
     }
 
-    OperatorParametersMockUtils.addCheckBoxSelections(operatorParametersMock, id, selections: _ *)
+    ParameterMockUtil.addCheckBoxSelections(operatorParametersMock, id, selections: _ *)
 
     class CheckBoxImpl extends AbstractCheckboxMock(values,
       selections, id, label, required) {}
@@ -204,7 +204,7 @@ class OperatorDialogMock(overrideParams: OperatorParametersMock, input: IOBase,
 
     assert(!(required && selection.equals("")))
 
-    OperatorParametersMockUtils.addTabularColumn(operatorParametersMock, id, selection)
+    ParameterMockUtil.addTabularColumn(operatorParametersMock, id, selection)
 
     class TabularDatasetColumnDropdownBoxImpl extends
     SingleElementSelectorMock(inputColumns.toSeq, selection, id, label, required) with
@@ -295,7 +295,7 @@ class OperatorDialogMock(overrideParams: OperatorParametersMock, input: IOBase,
       label + " is required. But no values for " +
       " the id  \"" + id + "\" were found.")
 
-    OperatorParametersMockUtils.addTabularColumns(operatorParametersMock, id, selection: _ *)
+    ParameterMockUtil.addTabularColumns(operatorParametersMock, id, selection: _ *)
 
     class TabularDatasetColumnCheckboxesImpl extends AbstractCheckboxMock(selection,
       inputColumns.toSeq, id, label, required) with TabularDatasetColumnCheckboxes {}

--- a/plugin-test/src/test/scala/com/alpine/plugin/test/unittests/FullOperatorTests.scala
+++ b/plugin-test/src/test/scala/com/alpine/plugin/test/unittests/FullOperatorTests.scala
@@ -8,7 +8,7 @@ import com.alpine.plugin.core.spark.utils.SparkRuntimeUtils
 import com.alpine.plugin.core.spark.utils.TestSparkContexts._
 import com.alpine.plugin.core.{OperatorListener, OperatorParameters}
 import com.alpine.plugin.test.mock.OperatorParametersMock
-import com.alpine.plugin.test.utils.{OperatorParametersMockUtils, SimpleAbstractSparkJobSuite}
+import com.alpine.plugin.test.utils.{ParameterMockUtil, SimpleAbstractSparkJobSuite}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row}
 
@@ -81,9 +81,9 @@ class FullOperatorTests extends SimpleAbstractSparkJobSuite {
     val dataFrameInput = sqlContext.createDataFrame(inputRows, inputSchema)
 
     val parameters = new OperatorParametersMock(colFilterName, uuid)
-    OperatorParametersMockUtils.addTabularColumn(parameters, "addTabularDatasetColumnDropdownBox", "name")
-    OperatorParametersMockUtils.addTabularColumns(parameters, "addTabularDatasetColumnCheckboxes", "name", "age")
-    OperatorParametersMockUtils.addHdfsParams(parameters, "ColumnSelector")
+    ParameterMockUtil.addTabularColumn(parameters, "addTabularDatasetColumnDropdownBox", "name")
+    ParameterMockUtil.addTabularColumns(parameters, "addTabularDatasetColumnCheckboxes", "name", "age")
+    ParameterMockUtil.addHdfsParams(parameters, "ColumnSelector")
     val operatorGUI = new TestGui
     val operatorJob = new TestSparkJob
     val (r, addendum) = runDataFrameThroughEntireDFTemplate(operatorGUI, operatorJob, parameters, dataFrameInput)

--- a/plugin-test/src/test/scala/com/alpine/plugin/test/unittests/OperatorDialogMockTests.scala
+++ b/plugin-test/src/test/scala/com/alpine/plugin/test/unittests/OperatorDialogMockTests.scala
@@ -4,7 +4,7 @@ import com.alpine.plugin.core.dialog.ColumnFilter
 import com.alpine.plugin.core.io.defaults.HdfsDelimitedTabularDatasetDefault
 import com.alpine.plugin.core.io.{ColumnDef, ColumnType, TSVAttributes, TabularSchema}
 import com.alpine.plugin.test.mock.{DataSourceMock, OperatorDataSourceManagerMock, OperatorParametersMock, OperatorSchemaManagerMock}
-import com.alpine.plugin.test.utils.OperatorParametersMockUtils
+import com.alpine.plugin.test.utils.ParameterMockUtil
 import org.scalatest.FunSuite
 
 import scala.com.alpine.plugin.test.mock.OperatorDialogMock
@@ -35,7 +35,7 @@ class OperatorDialogMockTests extends FunSuite {
     //add ColumnSelect
 
     val id = "id1"
-    OperatorParametersMockUtils.addTabularColumn(inputParams, id, "outlook")
+    ParameterMockUtil.addTabularColumn(inputParams, id, "outlook")
 
     val mockDialog = new OperatorDialogMock(inputParams, hdfIOInput, Some(golfInputSchema))
     mockDialog.addTabularDatasetColumnDropdownBox(id, "Single Column Outlook",
@@ -44,7 +44,7 @@ class OperatorDialogMockTests extends FunSuite {
       "Single Column Outlook", ColumnFilter.All, "main", required = true))
     assert(t.isFailure, "adding two things with the same name ")
 
-    OperatorParametersMockUtils.addTabularColumn(inputParams, "id2", "outlook")
+    ParameterMockUtil.addTabularColumn(inputParams, "id2", "outlook")
     val testColumnFilter = Try(mockDialog.addTabularDatasetColumnDropdownBox(
       "id2", "Single Column", ColumnFilter.NumericOnly, "2"))
     assert(testColumnFilter.isFailure, "Test column filter validation")

--- a/plugin-test/src/test/scala/com/alpine/plugin/test/unittests/TestOfTestUtils.scala
+++ b/plugin-test/src/test/scala/com/alpine/plugin/test/unittests/TestOfTestUtils.scala
@@ -5,7 +5,7 @@ import com.alpine.plugin.core.spark.utils.{SparkRuntimeUtils, TestSparkContexts}
 import com.alpine.plugin.core.utils.{HdfsParameterUtils, HdfsStorageFormat}
 import com.alpine.plugin.core.{OperatorListener, OperatorParameters}
 import com.alpine.plugin.test.mock.{OperatorParametersMock, SimpleOperatorListener}
-import com.alpine.plugin.test.utils.{OperatorParametersMockUtils, SimpleAbstractSparkJobSuite}
+import com.alpine.plugin.test.utils.{ParameterMockUtil, SimpleAbstractSparkJobSuite}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row}
 
@@ -39,8 +39,8 @@ class TestOfTestUtils extends SimpleAbstractSparkJobSuite {
 
     val expectedRows = Array(Row("Masha"), Row("Ulia"), Row("Nastya"))
 
-    OperatorParametersMockUtils.addTabularColumn(parameters, columnParamId, "name")
-    OperatorParametersMockUtils.addHdfsParams(parameters, "ColumnSelector")
+    ParameterMockUtil.addTabularColumn(parameters, columnParamId, "name")
+    ParameterMockUtil.addHdfsParams(parameters, "ColumnSelector")
 
     val result = operator.transform(parameters, dataFrame = dataFrameInput,
       new SparkRuntimeUtils(sc), new SimpleOperatorListener)
@@ -53,7 +53,7 @@ class TestOfTestUtils extends SimpleAbstractSparkJobSuite {
     val outputDir = "dir"
     val outputName = "name"
     val operatorParametersMock = new OperatorParametersMock("123", "thing")
-    OperatorParametersMockUtils.addHdfsParams(operatorParametersMock, outputName,
+    ParameterMockUtil.addHdfsParams(operatorParametersMock, outputName,
       outputDirectory = outputDir,
       storageFormat = HdfsStorageFormat.TSV,
       overwrite = false)
@@ -67,14 +67,14 @@ class TestOfTestUtils extends SimpleAbstractSparkJobSuite {
 
   test("Test Add single Column Method") {
     val operatorParametersMock = new OperatorParametersMock("123", "thing")
-    OperatorParametersMockUtils.addTabularColumn(operatorParametersMock, "id", "colName")
+    ParameterMockUtil.addTabularColumn(operatorParametersMock, "id", "colName")
     val (_, parameterValue) = operatorParametersMock.getTabularDatasetSelectedColumn("id")
     assert(parameterValue.equals("colName"))
   }
 
   test("Test Add multiple Column Method") {
     val operatorParametersMock = new OperatorParametersMock("123", "thing")
-    OperatorParametersMockUtils.addTabularColumns(operatorParametersMock, "id", "col1", "col2")
+    ParameterMockUtil.addTabularColumns(operatorParametersMock, "id", "col1", "col2")
     val (_, parameterValue) = operatorParametersMock.getTabularDatasetSelectedColumns("id")
     assert(parameterValue.sameElements(Array("col1", "col2")))
   }

--- a/plugin-test/src/test/scala/com/alpine/plugin/test/utils/ParameterMockUtil.scala
+++ b/plugin-test/src/test/scala/com/alpine/plugin/test/utils/ParameterMockUtil.scala
@@ -9,7 +9,7 @@ import com.alpine.plugin.core.utils.HdfsStorageFormat.HdfsStorageFormat
 import com.alpine.plugin.core.utils.{HdfsParameterUtils, HdfsStorageFormat}
 import com.alpine.plugin.test.mock.OperatorParametersMock
 
-object OperatorParametersMockUtils {
+object ParameterMockUtil {
 
   val defaultOutputDirectory = "target/testResults"
 

--- a/plugin-test/src/test/scala/com/alpine/plugin/test/utils/SimpleAbstractSparkJobSuite.scala
+++ b/plugin-test/src/test/scala/com/alpine/plugin/test/utils/SimpleAbstractSparkJobSuite.scala
@@ -51,7 +51,7 @@ class SimpleAbstractSparkJobSuite extends FunSuite {
                                   parameters: OperatorParametersMock): DataFrame = {
 
     val hdfsTabularDataset = createHdfsTabularDatasetLocal(dataFrame, Some(parameters.operatorInfo()),
-      OperatorParametersMockUtils.defaultOutputDirectory)
+      ParameterMockUtil.defaultOutputDirectory)
     val result = operator.onExecution(sc, appConf, hdfsTabularDataset, parameters, new SimpleOperatorListener)
     sparkUtils.getDataFrame(result)
   }


### PR DESCRIPTION
…ParameterMockUtil, because it is too much hassle to change all the dependent code.

@rachelwarren review?