### PR TITLE
Fixing group by bug in GroupByClassificationSQLTransformer.

### DIFF
--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/UnitModel.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/UnitModel.scala
@@ -32,7 +32,7 @@ object UnitTransformer extends Transformer {
   override def apply(row: Row): Row = row
 }
 
-case class UnitSQLTransformer(val model : UnitModel, sqlGenerator: SQLGenerator) extends SimpleSQLTransformer {
+case class UnitSQLTransformer(model : UnitModel, sqlGenerator: SQLGenerator) extends SimpleSQLTransformer {
   override def getSQLExpressions = {
     inputColumnNames.map(_.asColumnarSQLExpression(sqlGenerator))
   }

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/multiple/sql/GroupByClassificationSQLTransformer.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/multiple/sql/GroupByClassificationSQLTransformer.scala
@@ -32,7 +32,7 @@ class GroupByClassificationSQLTransformer(val model: GroupByClassificationModel,
 
     val groupBySQLExpression = combinedIntermediateLayers.layers.last.last._2.asColumnarSQLExpression(sqlGenerator)
 
-    val startingFeatureIndexByModel = modelsByGroup.map(_._1) zip cumulativeSum(modelsByGroup.map(_._2.inputFeatures.size))
+    val startingFeatureIndexByModel = modelsByGroup.map(_._1) zip cumulativeSum(modelsByGroup.map(_._2.classLabels.size))
 
     val finalLayerConfidences = model.classLabels.map(l => {
       (l, SQLUtility.groupBySQL(

--- a/alpine-model-pack/src/test/scala/com/alpine/model/pack/multiple/sql/GroupByClassificationSQLTransformerTest.scala
+++ b/alpine-model-pack/src/test/scala/com/alpine/model/pack/multiple/sql/GroupByClassificationSQLTransformerTest.scala
@@ -1,5 +1,8 @@
 package com.alpine.model.pack.multiple.sql
 
+import com.alpine.common.serialization.json.TypeWrapper
+import com.alpine.json.ModelJsonUtil
+import com.alpine.model.RowModel
 import com.alpine.model.pack.ml.{MultiLogisticRegressionModel, SingleLogisticRegression}
 import com.alpine.model.pack.multiple.GroupByClassificationModel
 import com.alpine.plugin.core.io.{ColumnDef, ColumnType}
@@ -77,5 +80,456 @@ class GroupByClassificationSQLTransformerTest extends FunSuite {
 
     assert(expectedSQL === selectStatement)
   }
+
+  test("Should generate the correct SQL for another model") {
+    val model: RowModel = ModelJsonUtil.compactGsonBuilder.create().fromJson(GroupBySampleModels.model, classOf[TypeWrapper[RowModel]]).value
+    val sql = model.sqlTransformer(simpleSQLGenerator).get.getSQL
+    val selectStatement = SQLUtility.getSelectStatement(sql, "\"demo\".\"golfnew\"", new AliasGenerator(), simpleSQLGenerator)
+
+    /**
+      * There is redundancy in the SQL, which we should fix at some point.
+      */
+    val expectedSQL =
+      """SELECT (CASE WHEN ("CONF0" > "CONF1")
+        |  THEN 'yes'
+        |        ELSE 'no' END) AS "PRED"
+        |FROM (SELECT
+        |        (CASE WHEN ("outlook" = 'overcast')
+        |          THEN "CONF0"
+        |         WHEN ("outlook" = 'rain')
+        |           THEN "CONF0_1"
+        |         WHEN ("outlook" = 'sunny')
+        |           THEN "CONF0_2"
+        |         ELSE NULL END) AS "CONF0",
+        |        (CASE WHEN ("outlook" = 'overcast')
+        |          THEN "CONF1"
+        |         WHEN ("outlook" = 'rain')
+        |           THEN "CONF1_1"
+        |         WHEN ("outlook" = 'sunny')
+        |           THEN "CONF1_2"
+        |         ELSE NULL END) AS "CONF1"
+        |      FROM (SELECT
+        |              "ce0"       AS "CONF0",
+        |              "baseVal"   AS "CONF1",
+        |              "column_8"  AS "CONF0_1",
+        |              "column_9"  AS "CONF1_1",
+        |              "column_19" AS "CONF0_2",
+        |              "column_20" AS "CONF1_2",
+        |              "column_0"  AS "outlook"
+        |            FROM (SELECT
+        |                    1 / "sum"                 AS "baseVal",
+        |                    "e0" / "sum"              AS "ce0",
+        |                    1 / "column_6"            AS "column_9",
+        |                    "column_7" / "column_6"   AS "column_8",
+        |                    1 / "column_17"           AS "column_20",
+        |                    "column_18" / "column_17" AS "column_19",
+        |                    "column_0"                AS "column_0"
+        |                  FROM (SELECT
+        |                          1 + "e0"        AS "sum",
+        |                          "e0"            AS "e0",
+        |                          1 + "column_5"  AS "column_6",
+        |                          "column_5"      AS "column_7",
+        |                          1 + "column_16" AS "column_17",
+        |                          "column_16"     AS "column_18",
+        |                          "column_0"      AS "column_0"
+        |                        FROM (SELECT
+        |                                EXP(11.566053522376023 + "temperature" * 1.1368683772161603E-13 +
+        |                                    "humidity" * 1.4210854715202004E-13 + "wind_0" * 3.637978807091713E-12 +
+        |                                    "wind_1" * 0.0)    AS "e0",
+        |                                EXP(11.566053522373863 + "column_1" * -4.884981308350689E-15 +
+        |                                    "column_3" * 5.828670879282072E-16 + "column_4" * -23.132107044747375 +
+        |                                    "column_2" * 0.0)  AS "column_5",
+        |                                EXP(-4.217191318784561 + "column_12" * -0.022443258429683213 +
+        |                                    "column_14" * -0.052069985289528796 + "column_15" * 22.74983888277704 +
+        |                                    "column_13" * 0.0) AS "column_16",
+        |                                "column_0"             AS "column_0"
+        |                              FROM (SELECT
+        |                                      "temperature" AS "temperature",
+        |                                      "humidity"    AS "humidity",
+        |                                      (CASE WHEN ("wind" = 'true')
+        |                                        THEN 1
+        |                                       ELSE 0 END)  AS "wind_0",
+        |                                      (CASE WHEN ("wind" = 'false')
+        |                                        THEN 1
+        |                                       ELSE 0 END)  AS "wind_1",
+        |                                      "temperature" AS "column_1",
+        |                                      "humidity"    AS "column_3",
+        |                                      (CASE WHEN ("wind" = 'true')
+        |                                        THEN 1
+        |                                       ELSE 0 END)  AS "column_4",
+        |                                      (CASE WHEN ("wind" = 'false')
+        |                                        THEN 1
+        |                                       ELSE 0 END)  AS "column_2",
+        |                                      "temperature" AS "column_12",
+        |                                      "humidity"    AS "column_14",
+        |                                      (CASE WHEN ("wind" = 'true')
+        |                                        THEN 1
+        |                                       ELSE 0 END)  AS "column_15",
+        |                                      (CASE WHEN ("wind" = 'false')
+        |                                        THEN 1
+        |                                       ELSE 0 END)  AS "column_13",
+        |                                      "outlook"     AS "column_0"
+        |                                    FROM
+        |                                      "demo"."golfnew") AS alias_0) AS alias_1) AS alias_2) AS alias_3) AS alias_4) AS alias_5"""
+        .stripMargin.replaceAll("\\s+", " ").replaceAllLiterally("\n", "")
+
+    assert(expectedSQL === selectStatement)
+  }
+
+}
+
+object GroupBySampleModels {
+
+  val model = s"""{
+  "type": "com.alpine.model.pack.multiple.GroupByClassificationModel",
+  "data": {
+    "groupByFeature": {
+      "columnName": "outlook",
+      "columnType": "String"
+    },
+    "modelsByGroup": {
+      "overcast": {
+        "type": "com.alpine.model.pack.multiple.PipelineClassificationModel",
+        "data": {
+          "preProcessors": [
+            {
+              "type": "com.alpine.model.pack.multiple.CombinerModel",
+              "data": {
+                "models": [
+                  {
+                    "id": "",
+                    "model": {
+                      "type": "com.alpine.model.pack.UnitModel",
+                      "data": {
+                        "inputFeatures": [
+                          {
+                            "columnName": "temperature",
+                            "columnType": "Double"
+                          },
+                          {
+                            "columnName": "humidity",
+                            "columnType": "Double"
+                          }
+                        ],
+                        "identifier": ""
+                      }
+                    }
+                  },
+                  {
+                    "id": "",
+                    "model": {
+                      "type": "com.alpine.model.pack.preprocess.OneHotEncodingModel",
+                      "data": {
+                        "oneHotEncodedFeatures": [
+                          {
+                            "hotValues": [
+                              "true",
+                              "false"
+                            ],
+                            "baseValue": {
+                              "type": "None"
+                            }
+                          }
+                        ],
+                        "inputFeatures": [
+                          {
+                            "columnName": "wind",
+                            "columnType": "String"
+                          }
+                        ],
+                        "identifier": ""
+                      }
+                    }
+                  }
+                ],
+                "identifier": "",
+                "inputFeatures": [
+                  {
+                    "columnName": "temperature",
+                    "columnType": "Double"
+                  },
+                  {
+                    "columnName": "humidity",
+                    "columnType": "Double"
+                  },
+                  {
+                    "columnName": "wind",
+                    "columnType": "String"
+                  }
+                ]
+              }
+            }
+          ],
+          "finalModel": {
+            "type": "com.alpine.model.pack.ml.MultiLogisticRegressionModel",
+            "data": {
+              "singleLORs": [
+                {
+                  "dependentValue": "yes",
+                  "coefficients": [
+                    1.1368683772161603E-13,
+                    1.4210854715202004E-13,
+                    3.637978807091713E-12,
+                    0.0
+                  ],
+                  "bias": 11.566053522376023
+                }
+              ],
+              "baseValue": "no",
+              "dependentFeatureName": "play",
+              "inputFeatures": [
+                {
+                  "columnName": "temperature",
+                  "columnType": "Double"
+                },
+                {
+                  "columnName": "humidity",
+                  "columnType": "Double"
+                },
+                {
+                  "columnName": "wind_0",
+                  "columnType": "Int"
+                },
+                {
+                  "columnName": "wind_1",
+                  "columnType": "Int"
+                }
+              ],
+              "identifier": "LOR"
+            }
+          },
+          "identifier": ""
+        }
+      },
+      "rain": {
+        "type": "com.alpine.model.pack.multiple.PipelineClassificationModel",
+        "data": {
+          "preProcessors": [
+            {
+              "type": "com.alpine.model.pack.multiple.CombinerModel",
+              "data": {
+                "models": [
+                  {
+                    "id": "",
+                    "model": {
+                      "type": "com.alpine.model.pack.UnitModel",
+                      "data": {
+                        "inputFeatures": [
+                          {
+                            "columnName": "temperature",
+                            "columnType": "Double"
+                          },
+                          {
+                            "columnName": "humidity",
+                            "columnType": "Double"
+                          }
+                        ],
+                        "identifier": ""
+                      }
+                    }
+                  },
+                  {
+                    "id": "",
+                    "model": {
+                      "type": "com.alpine.model.pack.preprocess.OneHotEncodingModel",
+                      "data": {
+                        "oneHotEncodedFeatures": [
+                          {
+                            "hotValues": [
+                              "true",
+                              "false"
+                            ],
+                            "baseValue": {
+                              "type": "None"
+                            }
+                          }
+                        ],
+                        "inputFeatures": [
+                          {
+                            "columnName": "wind",
+                            "columnType": "String"
+                          }
+                        ],
+                        "identifier": ""
+                      }
+                    }
+                  }
+                ],
+                "identifier": "",
+                "inputFeatures": [
+                  {
+                    "columnName": "temperature",
+                    "columnType": "Double"
+                  },
+                  {
+                    "columnName": "humidity",
+                    "columnType": "Double"
+                  },
+                  {
+                    "columnName": "wind",
+                    "columnType": "String"
+                  }
+                ]
+              }
+            }
+          ],
+          "finalModel": {
+            "type": "com.alpine.model.pack.ml.MultiLogisticRegressionModel",
+            "data": {
+              "singleLORs": [
+                {
+                  "dependentValue": "yes",
+                  "coefficients": [
+                    -4.884981308350689E-15,
+                    5.828670879282072E-16,
+                    -23.132107044747375,
+                    0.0
+                  ],
+                  "bias": 11.566053522373863
+                }
+              ],
+              "baseValue": "no",
+              "dependentFeatureName": "play",
+              "inputFeatures": [
+                {
+                  "columnName": "temperature",
+                  "columnType": "Double"
+                },
+                {
+                  "columnName": "humidity",
+                  "columnType": "Double"
+                },
+                {
+                  "columnName": "wind_0",
+                  "columnType": "Int"
+                },
+                {
+                  "columnName": "wind_1",
+                  "columnType": "Int"
+                }
+              ],
+              "identifier": "LOR"
+            }
+          },
+          "identifier": ""
+        }
+      },
+      "sunny": {
+        "type": "com.alpine.model.pack.multiple.PipelineClassificationModel",
+        "data": {
+          "preProcessors": [
+            {
+              "type": "com.alpine.model.pack.multiple.CombinerModel",
+              "data": {
+                "models": [
+                  {
+                    "id": "",
+                    "model": {
+                      "type": "com.alpine.model.pack.UnitModel",
+                      "data": {
+                        "inputFeatures": [
+                          {
+                            "columnName": "temperature",
+                            "columnType": "Double"
+                          },
+                          {
+                            "columnName": "humidity",
+                            "columnType": "Double"
+                          }
+                        ],
+                        "identifier": ""
+                      }
+                    }
+                  },
+                  {
+                    "id": "",
+                    "model": {
+                      "type": "com.alpine.model.pack.preprocess.OneHotEncodingModel",
+                      "data": {
+                        "oneHotEncodedFeatures": [
+                          {
+                            "hotValues": [
+                              "true",
+                              "false"
+                            ],
+                            "baseValue": {
+                              "type": "None"
+                            }
+                          }
+                        ],
+                        "inputFeatures": [
+                          {
+                            "columnName": "wind",
+                            "columnType": "String"
+                          }
+                        ],
+                        "identifier": ""
+                      }
+                    }
+                  }
+                ],
+                "identifier": "",
+                "inputFeatures": [
+                  {
+                    "columnName": "temperature",
+                    "columnType": "Double"
+                  },
+                  {
+                    "columnName": "humidity",
+                    "columnType": "Double"
+                  },
+                  {
+                    "columnName": "wind",
+                    "columnType": "String"
+                  }
+                ]
+              }
+            }
+          ],
+          "finalModel": {
+            "type": "com.alpine.model.pack.ml.MultiLogisticRegressionModel",
+            "data": {
+              "singleLORs": [
+                {
+                  "dependentValue": "yes",
+                  "coefficients": [
+                    -0.022443258429683213,
+                    -0.052069985289528796,
+                    22.74983888277704,
+                    0.0
+                  ],
+                  "bias": -4.217191318784561
+                }
+              ],
+              "baseValue": "no",
+              "dependentFeatureName": "play",
+              "inputFeatures": [
+                {
+                  "columnName": "temperature",
+                  "columnType": "Double"
+                },
+                {
+                  "columnName": "humidity",
+                  "columnType": "Double"
+                },
+                {
+                  "columnName": "wind_0",
+                  "columnType": "Int"
+                },
+                {
+                  "columnName": "wind_1",
+                  "columnType": "Int"
+                }
+              ],
+              "identifier": "LOR"
+            }
+          },
+          "identifier": ""
+        }
+      }
+    },
+    "identifier": "LOR"
+  }
+}"""
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@
 def publishParameters(module: String) = Seq(
   organization := "com.alpinenow",
   name := s"$module",
-  version := "1.5",
+  version := "1.5.1",
   publishMavenStyle := true,
   pomExtra := <scm>
     <url>git@github.com:AlpineNow/PluginSDK.git</url>

--- a/plugin-test/src/main/scala/com/alpine/plugin/test/utils/DataSets.scala
+++ b/plugin-test/src/main/scala/com/alpine/plugin/test/utils/DataSets.scala
@@ -14,7 +14,7 @@ import org.apache.spark.sql.{Row, DataFrame, SQLContext}
 case class IrisFlower(
   sepalLength: Double,
   sepalWidth: Double,
-  petaLlength: Double,
+  petalLength: Double,
   petalWidth: Double)
 
 


### PR DESCRIPTION
 I said inputFeatures.size, instead of classLabels.size. So it will show up whenever the two are different. I use this set of indexes in the group by to know where to find the confidence column for a particular sub-model / class label combination. Test added.

Unfortunately, this means publishing a new SDK version. Also added a spelling correction to DataSets.scala