### PR TITLE
Changes for SDK 1.9-alpha-1.

### DIFF
--- a/alpine-model-api/src/main/scala/com/alpine/util/SQLUtility.scala
+++ b/alpine-model-api/src/main/scala/com/alpine/util/SQLUtility.scala
@@ -4,7 +4,7 @@
  */
 package com.alpine.util
 
-import com.alpine.sql.{AliasGenerator, SQLGenerator}
+import com.alpine.sql.{AliasGenerator, DatabaseType, SQLGenerator}
 import com.alpine.transformer.sql._
 
 object SQLUtility {
@@ -87,7 +87,11 @@ object SQLUtility {
                   aliasGenerator: AliasGenerator,
                   sqlGenerator: SQLGenerator): String = {
     val selectStatement: String = getSelectStatement(sql, inputTableName, aliasGenerator, sqlGenerator)
-    s"""CREATE TABLE $outputTableName AS $selectStatement"""
+    sqlGenerator.dbType match {
+      // basically retain old functionality just in case
+      case DatabaseType.postgres | DatabaseType.greenplum | DatabaseType.oracle => s"""CREATE TABLE $outputTableName AS $selectStatement"""
+      case _ => sqlGenerator.getCreateTableAsSelectSQL(selectStatement, outputTableName)
+    }
   }
 
   def createTempTable(sql: LayeredSQLExpressions,

--- a/alpine-model-api/src/test/scala/com/alpine/util/SimpleSQLGenerator.scala
+++ b/alpine-model-api/src/test/scala/com/alpine/util/SimpleSQLGenerator.scala
@@ -92,9 +92,9 @@ class SimpleSQLGenerator extends SQLGenerator {
 
   override def getCreateTableOrViewAsSelectSQL(selectQuery: String, destinationTable: String, isView: Boolean): String = {
     if (isView) {
-      s"""CREATE TABLE $destinationTable AS ($selectQuery)"""
-    } else {
       s"""CREATE VIEW $destinationTable AS ($selectQuery)"""
+    } else {
+      s"""CREATE TABLE $destinationTable AS ($selectQuery)"""
     }
   }
 

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/ASTModel.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/ASTModel.scala
@@ -1,0 +1,28 @@
+/*
+ * COPYRIGHT (C) 2017 Alpine Data Labs Inc. All Rights Reserved.
+*/
+package com.alpine.model.pack.ast
+
+import com.alpine.common.serialization.json.TypeWrapper
+import com.alpine.model.RowModel
+import com.alpine.model.pack.ast.expressions.ASTExpression
+import com.alpine.plugin.core.io.ColumnDef
+import com.alpine.transformer.Transformer
+
+/**
+  * Created by Jennifer Thompson on 2/22/17.
+  */
+// TODO: SqlTransformer and PFAConverter.
+case class ASTModel(inputFeatures: Seq[ColumnDef],
+                    outputFeatures: Seq[ColumnDef],
+                    expressions: Seq[TypeWrapper[ASTExpression]])
+  extends RowModel {
+  override def transformer: Transformer = new Transformer {
+    override def apply(row: Row): Seq[Any] = {
+      val inputMap = (inputFeatures zip row).map {
+        case (ColumnDef(columnName, _), value) => (columnName, value)
+      }.toMap
+      expressions.map(e => e.execute(inputMap))
+    }
+  }
+}

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/ASTExpression.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/ASTExpression.scala
@@ -1,0 +1,56 @@
+/*
+ * COPYRIGHT (C) 2017 Alpine Data Labs Inc. All Rights Reserved.
+*/
+package com.alpine.model.pack.ast.expressions
+
+import com.alpine.common.serialization.json.TypeWrapper
+
+/**
+  * Created by Jennifer Thompson on 3/1/17.
+  */
+
+trait ASTExpression {
+  def inputNames: Set[String]
+
+  def execute(input: Map[String, Any]): Any
+}
+
+object ASTExpression {
+  implicit def extractValue(t: TypeWrapper[ASTExpression]): ASTExpression = t.value
+
+  implicit def wrapValue(value: ASTExpression): TypeWrapper[ASTExpression] = TypeWrapper(value)
+}
+
+abstract class SingleArgumentASSTExpression extends ASTExpression {
+  def argument: TypeWrapper[ASTExpression]
+
+  def inputNames: Set[String] = argument.inputNames
+}
+
+abstract class BinaryASSTExpression extends ASTExpression {
+  def left: TypeWrapper[ASTExpression]
+
+  def right: TypeWrapper[ASTExpression]
+
+  @transient lazy val inputNames: Set[String] = left.value.inputNames ++ right.value.inputNames
+}
+
+abstract class BinaryASSTExpressionWithNullHandling extends BinaryASSTExpression {
+  final override def execute(input: Map[String, Any]): Any = {
+    val leftVal = left.value.execute(input)
+    lazy val rightVal = right.value.execute(input)
+    if (leftVal == null || rightVal == null) {
+      null
+    } else {
+      executeForNonNullValues(leftVal, rightVal)
+    }
+  }
+
+  def executeForNonNullValues(leftVal: Any, rightVal: Any): Any
+}
+
+case class NameReferenceExpression(name: String) extends ASTExpression {
+  override def inputNames: Set[String] = Set(name)
+
+  override def execute(input: Map[String, Any]): Any = input(name)
+}

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/ComparisonExpressions.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/ComparisonExpressions.scala
@@ -1,0 +1,85 @@
+/*
+ * COPYRIGHT (C) 2017 Alpine Data Labs Inc. All Rights Reserved.
+*/
+package com.alpine.model.pack.ast.expressions
+
+import com.alpine.common.serialization.json.TypeWrapper
+
+/**
+  * Created by Jennifer Thompson on 2/23/17.
+  */
+case class GreaterThanExpression(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
+  extends BinaryASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    (left.execute(input), right.execute(input)) match {
+      case (x: Number, y: Number) => x.doubleValue() > y.doubleValue()
+      case _ => null
+    }
+  }
+}
+
+case class GreaterThanOrEqualsExpression(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
+  extends BinaryASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    (left.execute(input), right.execute(input)) match {
+      case (x: Number, y: Number) => x.doubleValue() >= y.doubleValue()
+      case _ => null
+    }
+  }
+}
+
+case class LessThanExpression(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
+  extends BinaryASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    (left.execute(input), right.execute(input)) match {
+      case (x: Number, y: Number) => x.doubleValue() < y.doubleValue()
+      case _ => null
+    }
+  }
+}
+
+case class LessThanOrEqualsExpression(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
+  extends BinaryASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    (left.execute(input), right.execute(input)) match {
+      case (x: Number, y: Number) => x.doubleValue() <= y.doubleValue()
+      case _ => null
+    }
+  }
+}
+
+class BetweenExpression(val value: TypeWrapper[ASTExpression], val min: TypeWrapper[ASTExpression], val max: TypeWrapper[ASTExpression])
+  extends ASTExpression {
+  @transient lazy val inputNames: Set[String] = value.inputNames ++ min.inputNames ++ max.inputNames
+
+  override def execute(input: Map[String, Any]): Any = {
+    (value.execute(input), min.execute(input), max.execute(input)) match {
+      case (v: Number, minimum: Number, maximum: Number) =>
+        v.doubleValue() >= minimum.doubleValue() && maximum.doubleValue() >= v.doubleValue()
+      case _ => null
+    }
+  }
+}
+
+case class EqualsExpression(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
+  extends BinaryASSTExpressionWithNullHandling {
+  override def executeForNonNullValues(leftVal: Any, rightVal: Any): Any = {
+    leftVal == rightVal
+  }
+}
+
+case class NotEqualsExpression(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
+  extends BinaryASSTExpressionWithNullHandling {
+  override def executeForNonNullValues(leftVal: Any, rightVal: Any): Any = {
+    leftVal != rightVal
+  }
+}
+
+case class IsDistinctFromExpression(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
+  extends BinaryASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    val leftVal = left.execute(input)
+    val rightVal = right.execute(input)
+    leftVal != rightVal
+  }
+}

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/LiteralExpressions.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/LiteralExpressions.scala
@@ -1,0 +1,32 @@
+/*
+ * COPYRIGHT (C) 2017 Alpine Data Labs Inc. All Rights Reserved.
+*/
+package com.alpine.model.pack.ast.expressions
+
+
+/**
+  * Created by Jennifer Thompson on 3/1/17.
+  */
+abstract class LiteralExpression extends ASTExpression {
+  override def inputNames: Set[String] = Set()
+}
+
+case class LongLiteralExpression(l: Long) extends LiteralExpression {
+  override def execute(input: Map[String, Any]): Long = l
+}
+
+case class StringLiteralExpression(s: String) extends LiteralExpression {
+  override def execute(input: Map[String, Any]): String = s
+}
+
+case class DoubleLiteralExpression(d: Double) extends LiteralExpression {
+  override def execute(input: Map[String, Any]): Double = d
+}
+
+case class BooleanLiteralExpression(boolean: Boolean) extends LiteralExpression {
+  override def execute(input: Map[String, Any]): Boolean = boolean
+}
+
+case class NullLiteralExpression() extends LiteralExpression {
+  override def execute(input: Map[String, Any]): Any = null
+}

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/LogicalExpressions.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/LogicalExpressions.scala
@@ -1,0 +1,65 @@
+/*
+ * COPYRIGHT (C) 2017 Alpine Data Labs Inc. All Rights Reserved.
+*/
+package com.alpine.model.pack.ast.expressions
+
+import com.alpine.common.serialization.json.TypeWrapper
+
+/**
+  * Created by Jennifer Thompson on 2/23/17.
+  */
+case class AndExpression(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression]) extends BinaryASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    val leftVal = left.execute(input)
+    val rightVal = right.execute(input)
+    (leftVal, rightVal) match {
+      case (true, true) => true
+      case (false, _) => false
+      case (_, false) => false
+      case _ => null
+    }
+  }
+}
+
+case class OrExpression(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression]) extends BinaryASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    val leftVal = left.execute(input)
+    val rightVal = right.execute(input)
+    (leftVal, rightVal) match {
+      case (false, false) => false
+      case (true, _) => true
+      case (_, true) => true
+      case _ => null
+    }
+  }
+}
+
+case class CaseWhenExpression(conditions: Seq[WhenThenClause], elseExpr: TypeWrapper[ASTExpression]) extends ASTExpression {
+  @transient lazy val inputNames: Set[String] = (conditions.flatMap(_.inputNames) ++ elseExpr.inputNames).toSet
+
+  override def execute(input: Map[String, Any]): Any = {
+    val i = conditions.iterator
+    while (i.hasNext) {
+      val next = i.next()
+      if (next.whenExpr.execute(input).asInstanceOf[Boolean]) {
+        return next.thenExpr.execute(input)
+      }
+    }
+    elseExpr.execute(input)
+  }
+}
+
+case class WhenThenClause(whenExpr: TypeWrapper[ASTExpression], thenExpr: TypeWrapper[ASTExpression]) {
+  @transient lazy val inputNames: Set[String] = whenExpr.inputNames ++ thenExpr.inputNames
+}
+
+case class NotExpression(argument: TypeWrapper[ASTExpression]) extends SingleArgumentASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    val arg = argument.execute(input)
+    arg match {
+      case true => false
+      case false => true
+      case _ => null
+    }
+  }
+}

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/MathExpressions.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/MathExpressions.scala
@@ -1,0 +1,121 @@
+/*
+ * COPYRIGHT (C) 2017 Alpine Data Labs Inc. All Rights Reserved.
+*/
+package com.alpine.model.pack.ast.expressions
+
+import com.alpine.common.serialization.json.TypeWrapper
+
+/**
+  * Created by Jennifer Thompson on 2/23/17.
+  */
+case class AddFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
+  extends BinaryASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    (left.execute(input), right.execute(input)) match {
+      case (x: Number, y: Number) => x.doubleValue() + y.doubleValue()
+      case _ => null
+    }
+  }
+}
+
+case class SubtractFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
+  extends BinaryASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    (left.execute(input), right.execute(input)) match {
+      case (x: Number, y: Number) => x.doubleValue() - y.doubleValue()
+      case _ => null
+    }
+  }
+}
+
+case class MultiplyFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
+  extends BinaryASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    (left.execute(input), right.execute(input)) match {
+      case (x: Number, y: Number) => x.doubleValue() * y.doubleValue()
+      case _ => null
+    }
+  }
+}
+
+case class DivideFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
+  extends BinaryASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    (left.execute(input), right.execute(input)) match {
+      case (x: Long, y: Long) => x / y
+      case (x: Int, y: Int) => x / y
+      case (x: Long, y: Int) => x / y
+      case (x: Int, y: Long) => x / y
+      case (x: Number, y: Number) => x.doubleValue() / y.doubleValue()
+      case _ => null
+    }
+  }
+}
+
+case class ModulusFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
+  extends BinaryASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    (left.execute(input), right.execute(input)) match {
+      case (x: Number, y: Number) => x.doubleValue() % y.doubleValue()
+      case _ => null
+    }
+  }
+}
+
+case class PowerFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
+  extends BinaryASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    (left.execute(input), right.execute(input)) match {
+      case (x: Number, y: Number) => math.pow(x.doubleValue(), y.doubleValue())
+      case _ => null
+    }
+  }
+}
+
+abstract class SingleArgumentDoubleFunction extends SingleArgumentASSTExpression {
+  def function: Double => Double
+
+  override def execute(input: Map[String, Any]): Any = {
+    val argVal = argument.execute(input)
+    argVal match {
+      case x: Number => function(x.doubleValue())
+      case _ => null
+    }
+  }
+}
+
+case class ExpFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
+  override def function: Double => Double = math.exp
+}
+
+case class SqrtFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
+  override def function: Double => Double = math.sqrt
+}
+
+case class CbrtFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
+  override def function: Double => Double = math.cbrt
+}
+
+case class NegativeFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
+  override def function: Double => Double = x => (-1) * x
+}
+
+case class AbsoluteValueFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
+  override def function: Double => Double = math.abs
+}
+
+case class CeilingFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
+  override def function: Double => Double = math.ceil
+}
+
+case class FloorFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
+  override def function: Double => Double = math.floor
+}
+
+case class NaturalLogFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
+  override def function: Double => Double = math.log
+}
+
+case class Log10Function(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
+  override def function: Double => Double = math.log10
+}

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/NullHandlingExpressions.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/NullHandlingExpressions.scala
@@ -1,0 +1,47 @@
+/*
+ * COPYRIGHT (C) 2017 Alpine Data Labs Inc. All Rights Reserved.
+*/
+package com.alpine.model.pack.ast.expressions
+
+import com.alpine.common.serialization.json.TypeWrapper
+
+/**
+  * https://www.postgresql.org/docs/8.4/static/functions-conditional.html
+  * Created by Jennifer Thompson on 2/23/17.
+  */
+case class CoalesceFunction(arguments: Seq[TypeWrapper[ASTExpression]]) extends ASTExpression {
+  override def inputNames: Set[String] = arguments.flatMap(_.inputNames).toSet
+
+  override def execute(input: Map[String, Any]): Any = {
+    var result: Any = null
+    val i = arguments.iterator
+    while (i.hasNext && result == null) {
+      result = i.next.execute(input)
+    }
+    result
+  }
+}
+
+case class IsNotNullExpression(argument: TypeWrapper[ASTExpression]) extends SingleArgumentASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    argument.execute(input) != null
+  }
+}
+
+case class IsNullExpression(argument: TypeWrapper[ASTExpression]) extends SingleArgumentASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    argument.execute(input) == null
+  }
+}
+
+// https://msdn.microsoft.com/en-us/library/ms177562.aspx
+case class NullIfFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression]) extends BinaryASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    val leftVal = left.execute(input)
+    if (leftVal == right.execute(input)) {
+      null
+    } else {
+      leftVal
+    }
+  }
+}

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/StringExpressions.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/StringExpressions.scala
@@ -1,0 +1,49 @@
+/*
+ * COPYRIGHT (C) 2017 Alpine Data Labs Inc. All Rights Reserved.
+*/
+package com.alpine.model.pack.ast.expressions
+
+import com.alpine.common.serialization.json.TypeWrapper
+
+/**
+  * Created by Jennifer Thompson on 2/23/17.
+  */
+case class ToUpperCaseFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    val argVal = argument.execute(input)
+    if (argVal == null) {
+      null
+    } else {
+      argVal.toString.toUpperCase
+    }
+  }
+}
+
+case class ToLowerCaseFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    val argVal = argument.execute(input)
+    if (argVal == null) {
+      null
+    } else {
+      argVal.toString.toLowerCase
+    }
+  }
+}
+
+case class StringLengthFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    val argVal = argument.execute(input)
+    if (argVal == null) {
+      null
+    } else {
+      argVal.toString.length
+    }
+  }
+}
+
+case class StringConcatenationFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
+  extends BinaryASSTExpressionWithNullHandling {
+  override def executeForNonNullValues(leftVal: Any, rightVal: Any): Any = {
+    leftVal.toString + rightVal.toString
+  }
+}

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/ml/KMeansModel.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/ml/KMeansModel.scala
@@ -100,7 +100,7 @@ class KMeansSQLTransformer(val model: KMeansModel, sqlGenerator: SQLGenerator) e
     val clusterExpressions = model.clusters.map(cluster => {
       val s = (cluster.centroid zip inputColumnNames).map {
         case (coordinate, name) =>
-          val diff = coordinate + " - " + name.escape(sqlGenerator)
+          val diff = sqlGenerator.doubleToString(coordinate) + " - " + name.escape(sqlGenerator)
           "(" + diff + ") * (" + diff + ")"
       }.mkString(" + ")
       // Use SQRT instead of POWER(s, 0.5) doesn't work for s = 0 (uses log in the implementation).

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/ml/sql/LinearRegressionSQLTransformer.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/ml/sql/LinearRegressionSQLTransformer.scala
@@ -12,10 +12,10 @@ import com.alpine.util.SQLUtility
 class LinearRegressionSQLTransformer(val model: LinearRegressionModel, sqlGenerator: SQLGenerator) extends RegressionSQLTransformer {
 
   def predictionExpression: String = {
-    model.intercept + " + " +
+    sqlGenerator.doubleToString(model.intercept) + " + " +
       SQLUtility.dotProduct(
         inputColumnNames.map(name => name.escape(sqlGenerator)),
-        model.coefficients.map(_.toString)
+        model.coefficients.map(sqlGenerator.doubleToString(_))
       )
   }
 

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/util/TransformerUtil.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/util/TransformerUtil.scala
@@ -47,12 +47,9 @@ object TransformerUtil {
     * @return Double representation of the number, or Double.NaN if impossible.
     */
   def anyToDouble(a: Any): Double = {
-    try {
-      a.asInstanceOf[Number].doubleValue()
-    }
-    catch {
-      case _: NullPointerException => Double.NaN
-      case _: ClassCastException => Double.NaN
+    a match {
+      case x: Number => x.doubleValue()
+      case _ => Double.NaN
     }
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbtassembly.Plugin._
 import AssemblyKeys._
 //import com.typesafe.sbt.SbtGit.GitKeys
 
-val sdkVersion = "1.9-alpha"
+val sdkVersion = "1.9-alpha-1"
 lazy val javaSourceVersion = "1.7"
 lazy val javaTargetVersion = "1.7"
 lazy val scalaMajorVersion = "2.10"

--- a/common/src/main/scala/com/alpine/sql/SQLExecutor.scala
+++ b/common/src/main/scala/com/alpine/sql/SQLExecutor.scala
@@ -303,7 +303,6 @@ trait SQLExecutor {
 
   /**
     * Generates the ColumnDef representations for columns of the given object.
-    *
     * @param objectName The fully quoted object name.
     * @throws java.sql.SQLException Throws exception if the object does not exist.
     * @return The ColumnDefs of the object.

--- a/common/src/main/scala/com/alpine/sql/SQLGenerator.scala
+++ b/common/src/main/scala/com/alpine/sql/SQLGenerator.scala
@@ -342,4 +342,15 @@ trait SQLGenerator {
     * @return         generated SQL statement
 	  */
   def getDropViewIfExistsSQL(viewName: String, cascade: Boolean = false): String
+
+	/**
+		* Converts a double to String representation. For most database vendors, this is just invoking toString on the double
+		* object. For Teradata, this will format the number of digits to no more than 15.
+		*
+		* @param d the double
+		* @return String representation of the double, limited to 15 characters for Teradata
+		*/
+	def doubleToString(d: Double): String = {
+		d.toString
+	}
 }

--- a/plugin-core/src/main/scala/com/alpine/plugin/OperatorDesignContext.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/OperatorDesignContext.scala
@@ -4,8 +4,24 @@
 package com.alpine.plugin
 
 import com.alpine.plugin.core.OperatorParameters
+import com.alpine.plugin.core.config.CustomOperatorConfig
 import com.alpine.plugin.core.datasource.{DataSource, OperatorDataSourceManager}
 import com.alpine.plugin.core.io.{IOMetadata, OperatorInfo, TabularSchema}
+import com.alpine.plugin.core.utils.ChorusAPICaller
+
+trait OperatorDesignContext {
+  def inputMetadata: Map[OperatorInfo, IOMetadata]
+
+  def inputSchemas: Map[String, TabularSchema]
+
+  def parameters: OperatorParameters
+
+  def operatorDataSourceManager: OperatorDataSourceManager
+
+  def chorusAPICaller: ChorusAPICaller
+
+  def config: CustomOperatorConfig
+}
 
 /**
   * Contains information that the operator may need in OperatorGUINode#getOperatorStatus.
@@ -19,10 +35,12 @@ import com.alpine.plugin.core.io.{IOMetadata, OperatorInfo, TabularSchema}
   *                                  (filtered for hadoop or database depending on the operator runtime class)
   *                                  that could be used by the operator at runtime.
   */
-class OperatorDesignContext(val inputMetadata: Map[OperatorInfo, IOMetadata],
-                            val parameters: OperatorParameters,
-                            val operatorDataSourceManager: OperatorDataSourceManager
-                           ) {
+class OperatorDesignContextImpl(val inputMetadata: Map[OperatorInfo, IOMetadata],
+                                val parameters: OperatorParameters,
+                                val operatorDataSourceManager: OperatorDataSourceManager,
+                                val chorusAPICaller: ChorusAPICaller,
+                                val config: CustomOperatorConfig
+                               ) extends OperatorDesignContext {
   /**
     * Equivalent to the input schemas argument that used to be passed directly to the
     * onInputOrParameterChange of OperatorGUINode by the Alpine Engine.
@@ -34,6 +52,7 @@ class OperatorDesignContext(val inputMetadata: Map[OperatorInfo, IOMetadata],
         case _ => None
       }
     }
+
 }
 
 /**
@@ -50,7 +69,6 @@ trait TabularIOMetadata extends IOMetadata {
 
   def datasource: DataSource
 }
-
 /**
   * The default class for pass along TabularSchema and data-source information.
   *

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/ChorusUserInfo.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/ChorusUserInfo.scala
@@ -1,5 +1,7 @@
 package com.alpine.plugin.core
 
+import com.alpine.plugin.core.dialog.ChorusFile
+
 /**
   * ChorusUserInfo
   *
@@ -14,3 +16,22 @@ case class ChorusUserInfo(userID: String, userName: String, sessionID: String)
   *                   ChorusAPICaller to get the workspace ID.
   */
 case class WorkflowInfo(workflowID: String)
+
+case class NotebookDetails(readyToExecute: Boolean,
+                           inputMetadata: NotebookIOInfo,
+                           outputMetadata: NotebookIOInfo)
+
+
+case class PythonNotebook(chorusFile: ChorusFile,
+                          userModifiedAt: String,
+                          serverStatus: String)
+
+
+case class PythonNotebookExecution(notebookId: String,
+                                   executionId: String,
+                                   status: String,
+                                   response: Option[String],
+                                   error: Option[String],
+                                   isFinished: Boolean)
+
+case class NotebookIOInfo(delimiter: String, quote: String, escape: String, columns: Seq[(String, String)])

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/ExecutionContext.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/ExecutionContext.scala
@@ -6,6 +6,9 @@ package com.alpine.plugin.core
 
 import java.io.File
 
+import com.alpine.plugin.core.config.CustomOperatorConfig
+import com.alpine.plugin.core.utils.ChorusAPICaller
+
 /**
   * The context for a plugin execution. This contains information about the
   * underlying platform, such as connection information and/or job submission,
@@ -14,7 +17,12 @@ import java.io.File
 trait ExecutionContext {
   def chorusUserInfo: ChorusUserInfo
 
+  def chorusAPICaller: ChorusAPICaller
+
   def workflowInfo: WorkflowInfo
 
   def recommendedTempDir: File
+
+  def config: CustomOperatorConfig
+
 }

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/OperatorMetadata.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/OperatorMetadata.scala
@@ -32,7 +32,8 @@ case class OperatorMetadata(name: String,
                             version: Int,
                             helpURL: Option[String],
                             icon: Option[OperatorIcon],
-                            toolTipText: Option[String]) {
+                            toolTipText: Option[String],
+                            usesJavascript: Boolean) {
 
   def this(name: String,
            category: String,
@@ -46,7 +47,8 @@ case class OperatorMetadata(name: String,
       version,
       emptyOptionIfEmptyString(helpURL),
       iconNamePrefixToIcon(iconNamePrefix),
-      None
+      None,
+      false
     )
   }
 
@@ -63,12 +65,50 @@ case class OperatorMetadata(name: String,
       version,
       emptyOptionIfEmptyString(helpURL),
       Option.apply(icon),
-      emptyOptionIfEmptyString(toolTipText)
+      emptyOptionIfEmptyString(toolTipText),
+      false
+    )
+  }
+
+  def this(name: String,
+           category: String,
+           author: String,
+           version: Int,
+           helpURL: String,
+           icon: OperatorIcon,
+           toolTipText: String,
+           usesJavascript: Boolean) = {
+    this(name,
+      category,
+      emptyOptionIfEmptyString(author),
+      version,
+      emptyOptionIfEmptyString(helpURL),
+      Option.apply(icon),
+      emptyOptionIfEmptyString(toolTipText),
+      usesJavascript
+    )
+  }
+
+  def this(name: String,
+           category: String,
+           author: Option[String],
+           version: Int,
+           helpURL: Option[String],
+           icon: Option[OperatorIcon],
+           toolTipText: Option[String]) = {
+    this(name,
+      category,
+      author,
+      version,
+      helpURL,
+      icon,
+      toolTipText,
+      false
     )
   }
 
   def this(name: String, category: String, version: Int = 1) = {
-    this(name, category, None, version, None, None, None)
+    this(name, category, None, version, None, None, None, false)
   }
 
   val resolvedToolTip: String = toolTipText.getOrElse("A " + category + " operator.")

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/OperatorParameters.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/OperatorParameters.scala
@@ -7,7 +7,6 @@ package com.alpine.plugin.core
 import com.alpine.plugin.core.annotation.AlpineSdkApi
 import com.alpine.plugin.core.dialog.ChorusFile
 import com.alpine.plugin.core.io.OperatorInfo
-import com.alpine.plugin.core.utils.ChorusAPICaller
 
 /**
   * :: AlpineSdkApi ::
@@ -18,18 +17,11 @@ import com.alpine.plugin.core.utils.ChorusAPICaller
 @AlpineSdkApi
 trait OperatorParameters extends Serializable {
 
-  /**
-    * This object contains the session id. It exposes a few supported methods to interact with
-    * the chorus API such as those to download a workfile.
-    */
-  def getChorusAPICaller: ChorusAPICaller
-
   def operatorInfo: OperatorInfo
 
   /**
     * Find out whether or not the given parameter Id is contained
     * in the object.
-    *
     * @param parameterId The Id of the parameter that we want to search for.
     * @return true if the parameter is contained. false otherwise.
     */
@@ -37,7 +29,6 @@ trait OperatorParameters extends Serializable {
 
   /**
     * Get the value of a parameter as a reference object.
-    *
     * @param parameterId The parameter Id that was used with an input field
     *                    in the OperatorDialog object.
     * @return The parameter value as a reference object.
@@ -46,7 +37,6 @@ trait OperatorParameters extends Serializable {
 
   /**
     * Get the string array value of a parameter (a checkboxes parameter).
-    *
     * @param parameterId The parameter Id of the multi item selector (checkboxes).
     * @return An array of selected values.
     */
@@ -56,7 +46,6 @@ trait OperatorParameters extends Serializable {
     * Get the selected columns from a tabular dataset output of an input operator.
     * NOTE: If the parameter was not required and the user did not input a value then this method
     * will return and empty array.
-    *
     * @param parameterId The parameter Id of the column checkboxes dialog element.
     * @return A tuple of a source operator name and an array of selected column
     *         names.
@@ -77,7 +66,6 @@ trait OperatorParameters extends Serializable {
     * Get the selected column from a tabular dataset output of an input operator.
     * NOTE: If the parameter was not required and the user didn't select a column this will return
     * an empty string.
-    *
     * @param parameterId The parameter Id of the column dropdown dialog element.
     * @return A tuple of a source operator name and a selected column name.
     */
@@ -109,7 +97,6 @@ trait OperatorParameters extends Serializable {
 
   /**
     * Get the value of a parameter as an integer.
-    *
     * @param parameterId The parameter Id that was used with an input field
     *                    in the OperatorDialog object.
     * @return The parameter value as an integer.
@@ -118,7 +105,6 @@ trait OperatorParameters extends Serializable {
 
   /**
     * Get the value of a parameter as a double.
-    *
     * @param parameterId The parameter Id that was used with an input field
     *                    in the OperatorDialog object.
     * @return The parameter value as a double.
@@ -127,18 +113,17 @@ trait OperatorParameters extends Serializable {
 
   /**
     * Get an iterator of parameter Ids.
-    *
     * @return An iterator of parameter Ids.
     */
   def getParameterIds: Iterator[String]
 
   /**
     * Get the chorus file stored added by a "ChorusFileSelector" parameter.
-    * The return type is a case class with a fileId and a fileName field.
-    * NOTE: If the parameter was not required and the user didn't select a Chorus file, this will return
-    * a ChorusFile with empty strings for fileId and fileName.
+    * The return type is a case class with a id and a name field.
+    *
+    * If no file was selected, this will return None.
     */
-  def getChorusFile(parameterId: String): ChorusFile
+  def getChorusFile(parameterId: String): Option[ChorusFile]
 
   def getAdvancedSparkParameters: scala.collection.mutable.Map[String, String]
 }

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/config/CustomOperatorConfig.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/config/CustomOperatorConfig.scala
@@ -1,0 +1,9 @@
+/*
+ * COPYRIGHT (C) 2017 Alpine Data Labs Inc. All Rights Reserved.
+*/
+package com.alpine.plugin.core.config
+
+/**
+  * Created by Jennifer Thompson on 4/5/17.
+  */
+class CustomOperatorConfig(val entries: Map[String, Any])

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/AdvancedSparkSettingsBox.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/AdvancedSparkSettingsBox.scala
@@ -3,18 +3,7 @@ package com.alpine.plugin.core.dialog
 /**
   * The advanced spark settings window
   */
-trait AdvancedSparkSettingsBox extends DialogElement {
-
-  def setAvailableValues(options: Iterator[String]): Unit
-
-  def setAvailableValues(options: Map[String, String]): Unit
-
-  def setParameters(options: Iterator[SparkParameter]): Unit
-
-  def addSetting(name: String, value: String): Unit
-
-  def getSetting(settingId: String): String
-}
+trait AdvancedSparkSettingsBox extends DialogElement
 
 case class SparkParameter(name: String,
                           displayName: String,

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/Checkboxes.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/Checkboxes.scala
@@ -11,11 +11,5 @@ import com.alpine.plugin.core.annotation.AlpineSdkApi
   */
 @AlpineSdkApi
 trait Checkboxes extends DialogElement {
-  def getValues: Iterator[String]
 
-  def addValue(value: String): Unit
-
-  def setCheckboxSelection(value: String, selected: Boolean): Unit
-
-  def getSelectedValues: Iterator[String]
 }

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/ChorusFileDropdown.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/ChorusFileDropdown.scala
@@ -3,13 +3,12 @@ package com.alpine.plugin.core.dialog
 /**
   * Created by rachelwarren on 11/18/16.
   */
-trait ChorusFileDropdown extends DialogElement {
-  def getExtensionFilter: Seq[String]
-}
 
-case class ChorusFile(fileName: String, fileId: String) {
+trait ChorusFileDropdown extends DialogElement
+
+case class ChorusFile(id: String, name: String) {
   val extension: String = {
-    val splits = fileName.split('.')
+    val splits = name.split('.')
     if (splits.length < 2) {
       // Chorus references Workflows just by name, without the .afm extension.
       ".afm"
@@ -18,7 +17,3 @@ case class ChorusFile(fileName: String, fileId: String) {
     }
   }
 }
-
-case class PythonNotebook(chorusFile: ChorusFile,
-                          userModifiedAt: String,
-                          serverStatus: String)

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/DBTableDropdownBox.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/DBTableDropdownBox.scala
@@ -10,6 +10,4 @@ import com.alpine.plugin.core.annotation.AlpineSdkApi
   * :: AlpineSdkApi ::
   */
 @AlpineSdkApi
-trait DBTableDropdownBox extends DropdownBox {
-  def schemaBoxID: String
-}
+trait DBTableDropdownBox extends DropdownBox

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/DataSourceDropdownBox.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/DataSourceDropdownBox.scala
@@ -11,7 +11,5 @@ import com.alpine.plugin.core.annotation.AlpineSdkApi
   */
 @AlpineSdkApi
 trait DataSourceDropdownBox extends DialogElement {
-  def getAvailableValues: Seq[String]
 
-  def getSelectedValue: String
 }

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/DialogElement.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/DialogElement.scala
@@ -11,15 +11,4 @@ import com.alpine.plugin.core.annotation.AlpineSdkApi
   * Operator Dialog elements. E.g., individual text boxes, drop-down boxes, etc.
   */
 @AlpineSdkApi
-trait DialogElement {
-  def getId: String
-
-  def getLabel: String
-
-  /**
-    * Since 1.2
-    *
-    * @return Whether the user is required to select a value for this parameter.
-    */
-  def isRequired: Boolean
-}
+trait DialogElement

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/DoubleBox.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/DoubleBox.scala
@@ -10,14 +10,4 @@ import com.alpine.plugin.core.annotation.AlpineSdkApi
   * :: AlpineSdkApi ::
   */
 @AlpineSdkApi
-trait DoubleBox extends DialogElement {
-  def getValue: Double
-
-  def getMin: Double
-
-  def getMax: Double
-
-  def getInclusiveMin: Boolean
-
-  def getInclusiveMax: Boolean
-}
+trait DoubleBox extends DialogElement

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/HdfsFileSelector.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/HdfsFileSelector.scala
@@ -10,10 +10,4 @@ import com.alpine.plugin.core.annotation.AlpineSdkApi
   * :: AlpineSdkApi ::
   */
 @AlpineSdkApi
-trait HdfsFileSelector extends DialogElement {
-  def isDirectorySelector: Boolean
-
-  def getSelectedPath: String
-
-  def setSelectedPath(path: String): Unit
-}
+trait HdfsFileSelector extends DialogElement

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/IntegerBox.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/IntegerBox.scala
@@ -10,10 +10,4 @@ import com.alpine.plugin.core.annotation.AlpineSdkApi
   * :: AlpineSdkApi ::
   */
 @AlpineSdkApi
-trait IntegerBox extends DialogElement {
-  def getValue: Int
-
-  def getMin: Int
-
-  def getMax: Int
-}
+trait IntegerBox extends DialogElement

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/OperatorDialog.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/OperatorDialog.scala
@@ -382,8 +382,7 @@ trait OperatorDialog {
     * Add a button for column checkboxes for a dataset input.
     * This can be used to select multiple columns from a tabular dataset
     * input. I.e., this will match tabular datasets coming in as inputs.
-    * In case of multiple dataset inputs, there'll be a separate
-    * column selector per dataset input.
+    * In case of multiple dataset inputs, use the method with parameter parentBoxId.
     *
     * @param id               String id for this parameter set.
     * @param label            The label (prefix) for this parameter set. In case there are
@@ -406,10 +405,41 @@ trait OperatorDialog {
                                        ): TabularDatasetColumnCheckboxes
 
   /**
+    * Add a button for column checkboxes for a dataset input.
+    * This can be used to select multiple columns from a tabular dataset
+    * input. I.e., this will match tabular datasets coming in as inputs.
+    * In case of multiple dataset inputs, you'll need a separate
+    * column selector per dataset input (with a distinct parentBoxId).
+    *
+    * @param id               String id for this parameter set.
+    * @param label            The label (prefix) for this parameter set. In case there are
+    *                         multiple input datasets, each column selector button will be
+    *                         prefixed by this label.
+    * @param columnFilter     Filter the columns that are selectable by their types.
+    * @param selectionGroupId If we want the available selections in this group
+    *                         to be dependent on other column selectors such
+    *                         that there's no duplicate selections, one could
+    *                         put multiple column selectors (checkboxes and/or
+    *                         dropboxes) in the same group.
+    * @param required         Whether the user is required to select a value for this parameter.
+    * @param parentBoxId      This parameter should be different from None if you have multiple dataset inputs. The Option value needs to be the id of a
+    *                         (required) ParentOperatorDropdownBox dialog element from which the dataset columns checkboxes will be generated according
+    *                         to the parent operator name selected.
+    * @return An input column checkboxes element.
+    */
+  def addTabularDatasetColumnCheckboxes(id: String,
+                                        label: String,
+                                        columnFilter: ColumnFilter,
+                                        selectionGroupId: String,
+                                        required: Boolean,
+                                        parentBoxId: Option[String]
+                                       ): TabularDatasetColumnCheckboxes
+
+
+  /**
     * Add a column selector dropdown box for a dataset input.
     * This can be used to select a single column from a tabular dataset.
-    * In case of multiple tabular dataset inputs, there'll be a separate
-    * column selector per dataset input.
+    * In case of multiple dataset inputs, use the method with parameter parentBoxId.
     *
     * @param id               String id for this parameter set.
     * @param label            The label (prefix) for this parameter set. In case there are
@@ -431,6 +461,39 @@ trait OperatorDialog {
                                           selectionGroupId: String,
                                           required: Boolean = true
                                         ): TabularDatasetColumnDropdownBox
+
+
+  /**
+    * Add a column selector dropdown box for a dataset input.
+    * This can be used to select a single column from a tabular dataset.
+    * In case of multiple tabular dataset inputs, you'll need a separate
+    * column selector per dataset input (with a distinct parentBoxId).
+    *
+    * @param id               String id for this parameter set.
+    * @param label            The label (prefix) for this parameter set. In case there are
+    *                         multiple input datasets, each column selector button will be
+    *                         prefixed by this label.
+    * @param columnFilter     Filter the columns that are selectable by their types.
+    * @param selectionGroupId If we want the available selections in this group
+    *                         to be dependent on other column selectors such
+    *                         that there's no duplicate selections, one could
+    *                         put multiple column selectors (checkboxes and/or
+    *                         dropboxes) in the same group.
+    * @param required         Whether the user is required to select a value for this parameter.
+    * @param parentBoxId      This parameter should be different from None if you have multiple dataset inputs. The Option value needs to be the id of a
+    *                         (required) ParentOperatorDropdownBox dialog element from which the dataset column dropdown will be generated according
+    *                         to the parent operator name selected.
+    * @return A single column selector dropdown box element.
+    */
+  def addTabularDatasetColumnDropdownBox(
+                                          id: String,
+                                          label: String,
+                                          columnFilter: ColumnFilter,
+                                          selectionGroupId: String,
+                                          required: Boolean,
+                                          parentBoxId: Option[String]
+                                        ): TabularDatasetColumnDropdownBox
+
 }
 
 /**

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/SingleItemSelector.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/SingleItemSelector.scala
@@ -8,12 +8,4 @@ package com.alpine.plugin.core.dialog
   * This is a trait for multi-choice, single selection dialog elements.
   * E.g., radio buttons, dropdown box, etc.
   */
-trait SingleItemSelector extends DialogElement {
-  def getValues: Iterator[String]
-
-  def addValue(value: String): Unit
-
-  def getSelectedValue: String
-
-  def setSelectedValue(value: String): Unit
-}
+trait SingleItemSelector extends DialogElement

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/StringBox.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/StringBox.scala
@@ -10,10 +10,4 @@ import com.alpine.plugin.core.annotation.AlpineSdkApi
   * :: AlpineSdkApi ::
   */
 @AlpineSdkApi
-trait StringBox extends DialogElement {
-  def setValue(value: String): Unit
-
-  def getValue: String
-
-  def getRegex: String
-}
+trait StringBox extends DialogElement

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/utils/ChorusUtils.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/utils/ChorusUtils.scala
@@ -1,3 +1,6 @@
+/**
+  * COPYRIGHT (C) 2017 Alpine Data Labs Inc. All Rights Reserved.
+  */
 package com.alpine.plugin.core.utils
 
 import java.io._
@@ -8,10 +11,6 @@ import com.alpine.plugin.core.dialog.ChorusFile
 import scala.util.Try
 
 /**
-  * COPYRIGHT (C) 2015 Alpine Data Labs Inc. All Rights Reserved.
-  */
-
-/**
   * Created by emiliedelongueau on 2/14/17.
   */
 object ChorusUtils {
@@ -20,19 +19,16 @@ object ChorusUtils {
     *
     * @param chorusFileName     the final name of the Chorus file to create (including the extension)
     * @param text               text to write (html-formatted, etc...)
-    * @param chorusAPICaller    created from getChorusAPICaller in OperatorParameters class
     * @param context            the Execution Context
     * @param newVersionIfExists if set to true and the chorusFileName already exists, a new version will be created
     * @return either Success[ChorusFile] or a Failure with the error message
     */
-  def writeTextChorusFile(
-                           chorusFileName: String,
-                           text: String,
-                           chorusAPICaller: ChorusAPICaller,
-                           context: ExecutionContext,
-                           newVersionIfExists: Boolean): Try[ChorusFile] = {
+  def writeTextChorusFile(chorusFileName: String,
+                          text: String,
+                          context: ExecutionContext,
+                          newVersionIfExists: Boolean): Try[ChorusFile] = {
 
-    val workspaceID = context.workflowInfo.workflowID
+    val currentWorkflowID = context.workflowInfo.workflowID
 
     //A temporary file is created, which we will then try to push to Chorus workspace.
     val tmpDir = context.recommendedTempDir
@@ -53,7 +49,7 @@ object ChorusUtils {
       fw.close()
     }
 
-    val chorusFile = chorusAPICaller.createOrUpdateChorusFile(workspaceID, outputFile, newVersionIfExists)
+    val chorusFile = context.chorusAPICaller.createOrUpdateChorusFile(currentWorkflowID, outputFile, newVersionIfExists)
     outputFile.delete()
     chorusFile
   }

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/utils/DBParameterUtils.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/utils/DBParameterUtils.scala
@@ -12,7 +12,7 @@ object DBParameterUtils extends TableOutputParameterUtils {
   @deprecated
   def addStandardDatabaseOutputParameters(operatorDialog: OperatorDialog,
                                           dataSourceManager: OperatorDataSourceManager,
-                                          defaultOutputName: String = operatorNameUUIDVariable
+                                          defaultOutputName: String = defaultTableName
                                          ): Seq[DialogElement] = {
     addStandardDBOutputParameters(operatorDialog, defaultOutputName)
   }
@@ -37,11 +37,11 @@ object DBParameterUtils extends TableOutputParameterUtils {
     * @return A sequence of each of the parameters that were created and added to the operatorDialog
     */
   def addStandardDBOutputParameters(operatorDialog: OperatorDialog,
-                                    defaultOutputName: String = operatorNameUUIDVariable
+                                    defaultOutputName: String = defaultTableName
                                    ): Seq[DialogElement] = {
     val outputType = addViewOrTableRadioButton(operatorDialog)
     val schema = addDBSchemaDropDownBox(operatorDialog)
-    val tableName = addResultTableNameParameter(operatorDialog, defaultTableName, "Output Table")
+    val tableName = addResultTableNameParameter(operatorDialog, defaultOutputName, "Output Table")
     val dropIfExists = addDropIfExistsParameter(operatorDialog)
     Seq(schema, outputType, dropIfExists, tableName)
   }

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/visualization/DBVisualModelFactoryImpl.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/visualization/DBVisualModelFactoryImpl.scala
@@ -1,0 +1,49 @@
+package com.alpine.plugin.core.visualization
+
+import java.util.Locale
+
+import com.alpine.plugin.core.io._
+
+/**
+  * Created by Jennifer Thompson on 2/16/17.
+  */
+class DBVisualModelFactoryImpl(var dbVisualHelper: DBVisualModelHelper) extends VisualModelFactory {
+
+  override def createCompositeVisualModel() = new CompositeVisualModel
+
+  override def createDefaultVisualModel(ioObject: IOBase): VisualModel = {
+    ioObject match {
+      case dbTable: DBTable => createDBTableVisualization(dbTable)
+      case string: IOString => TextVisualModel(string.value)
+      case _ => TextVisualModel(
+        "Alpine currently doesn't have a visualization module registered for " + ioObject.getClass.getCanonicalName
+      )
+    }
+  }
+
+  override def createTextVisualization(text: String): TextVisualModel = {
+    TextVisualModel(text)
+  }
+
+  override def createTabularDatasetVisualization(tabularDataset: TabularDataset): VisualModel = {
+    throw new RuntimeException("Cannot generate HDFS visualization in a DB operator.")
+  }
+
+  override def createPlainTextVisualModel(hdfsFile: HdfsFile): TextVisualModel = {
+    throw new RuntimeException("Cannot generate HDFS visualization in a DB operator.")
+  }
+
+  override def createDBTableVisualization(dbTable: DBTable): VisualModel = {
+    dbVisualHelper.createDBTableVisualization(dbTable)
+  }
+
+  override def createDBTableVisualization(schemaName: String, tableName: String): VisualModel = {
+    dbVisualHelper.createDBTableVisualization(schemaName, tableName)
+  }
+
+  override def createHtmlTextVisualization(text: String): HtmlVisualModel = {
+    HtmlVisualModel(text)
+  }
+
+  override def locale: Locale = dbVisualHelper.locale
+}

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/visualization/HDFSVisualModelFactoryImpl.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/visualization/HDFSVisualModelFactoryImpl.scala
@@ -1,0 +1,55 @@
+package com.alpine.plugin.core.visualization
+
+import java.util.Locale
+
+import com.alpine.plugin.core.io._
+
+/**
+  * Created by Jennifer Thompson on 2/16/17.
+  */
+class HDFSVisualModelFactoryImpl(var hdfsVisualHelper: HDFSVisualModelHelper) extends VisualModelFactory {
+
+  override def createCompositeVisualModel() = new CompositeVisualModel
+
+  override def createDefaultVisualModel(ioObject: IOBase): VisualModel = {
+    ioObject match {
+      case dataset: TabularDataset => createTabularDatasetVisualization(dataset)
+      case string: IOString => TextVisualModel(string.value)
+      case file: HdfsFile =>
+        // We have this condition after the TabularDataset one,
+        // because some TabularDatasets are HdfsFiles.
+        createPlainTextVisualModel(file)
+      case _ => TextVisualModel(
+        "Alpine currently doesn't have a visualization module registered for " + ioObject.getClass.getCanonicalName
+      )
+    }
+  }
+
+  override def createTextVisualization(text: String): TextVisualModel = {
+    TextVisualModel(text)
+  }
+
+  override def createTabularDatasetVisualization(tabularDataset: TabularDataset): TabularVisualModel = {
+    hdfsVisualHelper.createTabularDatasetVisualization(tabularDataset)
+  }
+
+  override def createPlainTextVisualModel(hdfsFile: HdfsFile): TextVisualModel = {
+    hdfsVisualHelper.createPlainTextVisualModel(hdfsFile)
+  }
+
+  override def createDBTableVisualization(dbTable: DBTable): VisualModel = {
+    throw new RuntimeException("Cannot generate DB Table visualization in a Spark operator.")
+  }
+
+  override def createDBTableVisualization(schemaName: String, tableName: String): VisualModel = {
+    throw new RuntimeException("Cannot generate DB Table visualization in a Spark operator.")
+  }
+
+  override def createHtmlTextVisualization(text: String): HtmlVisualModel = {
+    HtmlVisualModel(text)
+  }
+
+  override def locale: Locale = {
+    hdfsVisualHelper.locale
+  }
+}

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/visualization/HDFSVisualModelHelper.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/visualization/HDFSVisualModelHelper.scala
@@ -14,7 +14,6 @@ trait HDFSVisualModelHelper {
 
   /**
     * Create a visualization for an Hdfs tabular dataset.
-    *
     * @param dataset A Hdfs tabular dataset that we want to visualize.
     * @return A visualization of the sample.
     */
@@ -22,7 +21,6 @@ trait HDFSVisualModelHelper {
 
   /**
     * Gets the first few lines of the HdfsFile as plain text.
-    *
     * @param hdfsFile The file to preview.
     * @return The first few lines of the file as a visual model.
     */

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/visualization/TextVisualModel.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/visualization/TextVisualModel.scala
@@ -18,3 +18,5 @@ case class TextVisualModel(content: String) extends VisualModel
   * @param html An HTML String
   */
 case class HtmlVisualModel(html: String) extends VisualModel
+
+case class JavascriptVisualModel(functionName: String, data: Option[Any]) extends VisualModel

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/visualization/VisualModelFactory.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/visualization/VisualModelFactory.scala
@@ -47,7 +47,6 @@ trait VisualModelFactory {
 
   /**
     * Gets the first few lines of the HdfsFile as plain text.
-    *
     * @param hdfsFile The file to preview.
     * @return The first few lines of the file as a visual model.
     */

--- a/plugin-test/src/main/scala/com/alpine/plugin/test/mock/ChorusAPICallerMock.scala
+++ b/plugin-test/src/main/scala/com/alpine/plugin/test/mock/ChorusAPICallerMock.scala
@@ -2,33 +2,46 @@ package com.alpine.plugin.test.mock
 
 import java.io.{File, FileInputStream, InputStream}
 
-import com.alpine.plugin.core.dialog.{ChorusFile, PythonNotebook}
+import com.alpine.plugin.core.dialog.ChorusFile
 import com.alpine.plugin.core.utils.ChorusAPICaller
+import com.alpine.plugin.core.{NotebookDetails, PythonNotebook, PythonNotebookExecution}
 
-import scala.util.{Failure, Try}
+import scala.util.Try
 
 class ChorusAPICallerMock(val workfiles: Seq[ChorusFileInWorkspaceMock]) extends ChorusAPICaller {
 
   val workfileMap: Map[String, ChorusFileInWorkspaceMock] = {
-    workfiles.map(w => (w.wf.fileId, w)).toMap
+    workfiles.map(w => (w.wf.id, w)).toMap
   }
 
-  /**
-    *
-    * Mocks the download workfile method, but reading the local workflow associated with the workfileID
-    */
-  override def getWorkfileAsInputStream(workFileId: String): Try[InputStream] = {
-    try {
-      val mockWf = this.workfileMap(workFileId)
+  override def readWorkfileInputStream[R](workFileID: String, readFunction: (InputStream) => R): Try[R] = {
+    Try {
+      val mockWf = this.workfileMap(workFileID)
       val workfilePath = mockWf.workfilePath.get
       val f = new File(workfilePath)
       val stream = new FileInputStream(f)
-      Try(stream)
-    } catch {
-      case (e: Exception) => Failure[InputStream](e)
+      try {
+        readFunction(stream)
+      } finally {
+        stream.close()
+      }
     }
   }
 
+  override def readWorkfileInputStream[R](workfile: ChorusFile, readFunction: (InputStream) => R): Try[R] = {
+    readWorkfileInputStream(workfile.id, readFunction)
+  }
+
+  override def readWorkfileAsText(workFileID: String): Try[String] = {
+    val readFunction: InputStream => String = {
+      in: InputStream => scala.io.Source.fromInputStream(in).getLines().mkString("\n")
+    }
+    readWorkfileInputStream(workFileID, readFunction)
+  }
+
+  override def readWorkfileAsText(workfile: ChorusFile): Try[String] = {
+    readWorkfileAsText(workfile.id)
+  }
   /**
     * Runs a workfile and returns the workfile object if successful
     * Note: this will not fail if the workfile exists but cannot be run (e.g. if the notebook server
@@ -41,7 +54,14 @@ class ChorusAPICallerMock(val workfiles: Seq[ChorusFileInWorkspaceMock]) extends
 
   override def runNotebook(workfileId: String): Try[PythonNotebook] = ???
 
+  override def getNotebookDetails(notebookID: String): Try[NotebookDetails] = ???
+
+  override def runNotebookExecution(notebook_id: String, input_path1: String, outputPath: String): Try[PythonNotebookExecution] = ???
+
+  override def getNotebookExecutionStatus(notebook_id: String, execution_id: String): Try[PythonNotebookExecution] = ???
+
   override def createOrUpdateChorusFile(workspaceId: String, file: File, overwrite: Boolean): Try[ChorusFile] = ???
+
 }
 
 object ChorusAPICallerMock {

--- a/plugin-test/src/main/scala/com/alpine/plugin/test/mock/DBVisualModelHelperMock.scala
+++ b/plugin-test/src/main/scala/com/alpine/plugin/test/mock/DBVisualModelHelperMock.scala
@@ -1,0 +1,26 @@
+/*
+ * COPYRIGHT (C) 2017 Alpine Data Labs Inc. All Rights Reserved.
+*/
+package com.alpine.plugin.test.mock
+
+import java.util.Locale
+
+import com.alpine.plugin.core.io.DBTable
+import com.alpine.plugin.core.visualization.{DBVisualModelHelper, TextVisualModel, VisualModel}
+
+/**
+  * Created by Jennifer Thompson on 3/24/17.
+  */
+class DBVisualModelHelperMock extends DBVisualModelHelper {
+
+  override def createDBTableVisualization(dbTable: DBTable): VisualModel = {
+    createDBTableVisualization(dbTable.schemaName, dbTable.tableName)
+  }
+
+  override def createDBTableVisualization(schemaName: String, tableName: String): VisualModel = {
+    TextVisualModel("In the production environment, this would be replaced with a preview of the contents of the table at "
+      + schemaName + "." + tableName + " from the database.")
+  }
+
+  override def locale: Locale = Locale.ENGLISH
+}

--- a/plugin-test/src/main/scala/com/alpine/plugin/test/mock/HDFSVisualModelHelperMock.scala
+++ b/plugin-test/src/main/scala/com/alpine/plugin/test/mock/HDFSVisualModelHelperMock.scala
@@ -1,0 +1,26 @@
+/*
+ * COPYRIGHT (C) 2017 Alpine Data Labs Inc. All Rights Reserved.
+*/
+package com.alpine.plugin.test.mock
+
+import java.util.Locale
+
+import com.alpine.plugin.core.io.{HdfsFile, TabularDataset}
+import com.alpine.plugin.core.visualization.{HDFSVisualModelHelper, TabularVisualModel, TextVisualModel}
+
+/**
+  * Created by Jennifer Thompson on 3/24/17.
+  */
+class HDFSVisualModelHelperMock extends HDFSVisualModelHelper {
+
+  override def createTabularDatasetVisualization(dataset: TabularDataset): TabularVisualModel = {
+    TabularVisualModel(Seq(), dataset.tabularSchema.definedColumns)
+  }
+
+  override def createPlainTextVisualModel(hdfsFile: HdfsFile): TextVisualModel = {
+    TextVisualModel("In the production environment, this would be replaced with a preview of the contents of the file at "
+      + hdfsFile.path + " on the hadoop cluster.")
+  }
+
+  override def locale: Locale = Locale.ENGLISH
+}

--- a/plugin-test/src/main/scala/com/alpine/plugin/test/mock/OperatorParametersMock.java
+++ b/plugin-test/src/main/scala/com/alpine/plugin/test/mock/OperatorParametersMock.java
@@ -10,7 +10,7 @@ import java.util.HashMap;
 
 import com.alpine.plugin.core.dialog.ChorusFile;
 import com.alpine.plugin.core.io.OperatorInfo;
-import com.alpine.plugin.core.utils.ChorusAPICaller;
+import scala.Option;
 import scala.Tuple2;
 import scala.collection.JavaConversions;
 
@@ -26,28 +26,11 @@ public class OperatorParametersMock implements OperatorParameters, Serializable 
 
     private final String operatorName;
     private final String operatorUUID;
-    public String sessionId; //I am not sure if this is useful to expose
-    public ChorusAPICallerMock chorusAPICaller;
-
-    public OperatorParametersMock(String operatorName, String uuid, ChorusAPICallerMock apiCallerMock) {
-        this.operatorName = operatorName;
-        this.operatorUUID = uuid;
-        this.sessionId = Math.random() + "";
-        this.chorusAPICaller = apiCallerMock;
-        this.parameterMap = new HashMap<>();
-    }
 
     public OperatorParametersMock(String operatorName, String operatorUUID) {
         this.operatorName = operatorName;
         this.operatorUUID = operatorUUID;
         this.parameterMap = new HashMap<>();
-        this.sessionId = Math.random() + "";
-        this.chorusAPICaller = ChorusAPICallerMock.apply();
-    }
-
-    public OperatorParametersMock updateChorusAPICaller(ChorusAPICallerMock newAPICaller) {
-        this.chorusAPICaller = newAPICaller;
-        return this;
     }
 
     @Override
@@ -61,11 +44,6 @@ public class OperatorParametersMock implements OperatorParameters, Serializable 
 
     public void setValue(String parameterId, Object value) {
         this.parameterMap.put(parameterId, value);
-    }
-
-    @Override
-    public ChorusAPICaller getChorusAPICaller() {
-        return chorusAPICaller;
     }
 
     public Object getValue(String parameterId) {
@@ -137,9 +115,13 @@ public class OperatorParametersMock implements OperatorParameters, Serializable 
     }
 
     @Override
-    public ChorusFile getChorusFile(String parameterId) {
+    public Option<ChorusFile> getChorusFile(String parameterId) {
         //return type is the same as getTabularDatasetSelectedColumn
-        return (ChorusFile) this.parameterMap.get(parameterId);
+        return (Option<ChorusFile>) this.parameterMap.get(parameterId);
+    }
+
+    public void setChorusFile(String parameterId, ChorusFile file) {
+        this.parameterMap.put(parameterId, Option.apply(file));
     }
 
     public String getTabularDatasetSelectedColumnName(String parameterId) {
@@ -151,8 +133,6 @@ public class OperatorParametersMock implements OperatorParameters, Serializable 
         if (param instanceof java.util.Map) {
             //Is a column selector
             return getTabularDatasetSelectedColumnName(parameterId);
-        } else if (param instanceof ChorusFile) {
-            return getChorusFile(parameterId).fileId();
         } else {
             return param.toString();
         }

--- a/plugin-test/src/main/scala/com/alpine/plugin/test/mock/SparkExecutionContextMock.scala
+++ b/plugin-test/src/main/scala/com/alpine/plugin/test/mock/SparkExecutionContextMock.scala
@@ -1,0 +1,52 @@
+/*
+ * COPYRIGHT (C) 2017 Alpine Data Labs Inc. All Rights Reserved.
+*/
+package com.alpine.plugin.test.mock
+
+import java.io.{File, InputStream, OutputStream}
+
+import com.alpine.plugin.core.config.CustomOperatorConfig
+import com.alpine.plugin.core.{ChorusUserInfo, OperatorListener, OperatorParameters, WorkflowInfo}
+import com.alpine.plugin.core.io.IOBase
+import com.alpine.plugin.core.spark.{SparkExecutionContext, SparkIOTypedPluginJob, SparkJobConfiguration, SubmittedSparkJob}
+import com.alpine.plugin.core.utils.ChorusAPICaller
+import com.alpine.plugin.core.visualization.HDFSVisualModelHelper
+import org.apache.hadoop.fs.FileSystem
+
+/**
+  * This is a mock version of SparkExecutionContext, for use in tests.
+  * This defines the HDFSVisualModelHelper as HDFSVisualModelHelperMock,
+  * and chorusAPICaller according to the argument.
+  *
+  * It can be extended for different behaviour (e.g. mocking the file system).
+  */
+class SparkExecutionContextMock(chorusAPICallerMock: ChorusAPICaller) extends SparkExecutionContext {
+
+  override def submitJob[I <: IOBase, O <: IOBase, JOB <: SparkIOTypedPluginJob[I, O]](jobClass: Class[JOB], input: I, params: OperatorParameters, sparkConf: SparkJobConfiguration, listener: OperatorListener): SubmittedSparkJob[O] = ???
+
+  override def doHdfsAction[T](fs: (FileSystem) => T): T = ???
+
+  override def openPath(path: String): InputStream = ???
+
+  override def createPath(path: String, overwrite: Boolean): OutputStream = ???
+
+  override def appendPath(path: String): OutputStream = ???
+
+  override def deletePath(path: String, recursive: Boolean): Boolean = ???
+
+  override def exists(path: String): Boolean = ???
+
+  override def mkdir(path: String): Boolean = ???
+
+  override def visualModelHelper: HDFSVisualModelHelper = new HDFSVisualModelHelperMock
+
+  override def chorusUserInfo: ChorusUserInfo = ???
+
+  override def chorusAPICaller: ChorusAPICaller = chorusAPICallerMock
+
+  override def workflowInfo: WorkflowInfo = ???
+
+  override def recommendedTempDir: File = ???
+
+  override def config: CustomOperatorConfig = ???
+}

--- a/plugin-test/src/main/scala/com/alpine/plugin/test/mock/VisualModelFactoryMock.scala
+++ b/plugin-test/src/main/scala/com/alpine/plugin/test/mock/VisualModelFactoryMock.scala
@@ -5,6 +5,7 @@ import java.util.Locale
 import com.alpine.plugin.core.io._
 import com.alpine.plugin.core.visualization._
 
+@deprecated("Use new DBVisualModelFactoryImpl(DBVisualModelHelperMock) or new HDFSVisualModelFactoryImpl(HDFSVisualModelHelperMock) instead.")
 class VisualModelFactoryMock extends VisualModelFactory {
 
   override def createCompositeVisualModel(): CompositeVisualModel = {

--- a/plugin-test/src/test/scala/com/alpine/plugin/test/sparktests/BadDataReportingUtilsTest.scala
+++ b/plugin-test/src/test/scala/com/alpine/plugin/test/sparktests/BadDataReportingUtilsTest.scala
@@ -153,7 +153,7 @@ class BadDataReportingUtilsTest extends SimpleAbstractSparkJobSuite {
 
     val f = new File(new java.io.File(HdfsParameterUtils.getBadDataPath(mockParams)))
     if (f.isDirectory) {
-      f.deleteRecursively();
+      f.deleteRecursively()
     }
     val (goodData, message) = BadDataReportingUtils.filterNullDataAndReportGeneral(_.anyNull,
       inputData, mockParams, sparkUtils, "because it is evil")

--- a/plugin-test/src/test/scala/com/alpine/plugin/test/unittests/OperatorDialogMockTests.scala
+++ b/plugin-test/src/test/scala/com/alpine/plugin/test/unittests/OperatorDialogMockTests.scala
@@ -60,10 +60,8 @@ class OperatorDialogMockTests extends FunSuite {
   }
 
   test("Chorus workfile selector ") {
-    val chorusFile = ChorusFile("workFileName.afm", "workFileId")
-    val workfileInWorkspace = Seq(ChorusFileInWorkspaceMock(chorusFile, None))
-    inputParams.updateChorusAPICaller(new ChorusAPICallerMock(workfileInWorkspace))
-    inputParams.setValue("paramId", chorusFile)
+    val chorusFile = ChorusFile("workFileName.afm", "17")
+    inputParams.setChorusFile("paramId", chorusFile)
 
     val mockDialog = new OperatorDialogMock(
       overrideParams = inputParams,
@@ -73,19 +71,11 @@ class OperatorDialogMockTests extends FunSuite {
     mockDialog.addChorusFileDropdownBox("paramId", "ChorusFileDropDown", Set(".afm"), isRequired = true)
     val newParams = mockDialog.getNewParameters
     val paramValue = newParams.getChorusFile("paramId")
-    assert(paramValue.equals(chorusFile))
-
-    val mockDialogWOMap = new OperatorDialogMock(inputParams.updateChorusAPICaller(ChorusAPICallerMock()), hdfIOInput, None)
-    assert(Try(mockDialogWOMap.addChorusFileDropdownBox("paramId", "ChorusFileDropDown",
-      Set(".afm"), isRequired = true)).isFailure)
+    assert(paramValue.get === chorusFile)
   }
 
   test("Using string array value and string value to return column selectors") {
-    val chorusFile = ChorusFile("workFileName.afm", "workFileId")
-    val workfileInWorkspace = Seq(ChorusFileInWorkspaceMock(chorusFile, None))
-    val p = new OperatorParametersMock("name", "uuid",
-      new ChorusAPICallerMock(workfileInWorkspace))
-    p.setValue("chorusFile", chorusFile)
+    val p = new OperatorParametersMock("name", "uuid")
     OperatorParameterMockUtil.addTabularColumns(p, "tabularColumns", "outlook", "play")
     OperatorParameterMockUtil.addTabularColumn(p, "tabularColumn", "outlook")
 
@@ -96,12 +86,9 @@ class OperatorDialogMockTests extends FunSuite {
 
     mockDialog.addTabularDatasetColumnDropdownBox("tabularColumn", "label", ColumnFilter.All, "a")
     mockDialog.addTabularDatasetColumnCheckboxes("tabularColumns", "label", ColumnFilter.All, "b")
-    mockDialog.addChorusFileDropdownBox("chorusFile", "label", Set(".afm"), isRequired = true)
 
     val p1 = p.getStringValue("tabularColumn")
-    assert(p1.equalsIgnoreCase("outlook"))
-    val p2 = p.getStringValue("chorusFile")
-    assert(p2.equalsIgnoreCase("workFileId"))
+    assert(p1 === "outlook")
     val p3 = p.getStringArrayValue("tabularColumns")
     assert(p3.contains("outlook") && p3.contains("play"))
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.13

--- a/sbt
+++ b/sbt
@@ -2,22 +2,95 @@
 #
 # A more capable sbt runner, coincidentally also called sbt.
 # Author: Paul Phillips <paulp@improving.org>
-# Copied from https://github.com/paulp/sbt-extras/blob/master/sbt on Sept 22 2015.
+# Taken from https://github.com/paulp/sbt-extras/blob/master/sbt on March 20th, 2017
+# License is BSD-3-Clause, see accompanying SBT_LICENSE.txt
 
-# todo - make this dynamic
-declare -r sbt_release_version="0.13.7"
-declare -r sbt_unreleased_version="0.13.7"
+set -o pipefail
+
+declare -r sbt_release_version="0.13.13"
+declare -r sbt_unreleased_version="0.13.14-RC1"
+
+declare -r latest_212="2.12.1"
+declare -r latest_211="2.11.8"
+declare -r latest_210="2.10.6"
+declare -r latest_29="2.9.3"
+declare -r latest_28="2.8.2"
+
 declare -r buildProps="project/build.properties"
 
-declare sbt_jar sbt_dir sbt_create sbt_version
-declare scala_version sbt_explicit_version
-declare verbose noshare batch trace_level log_level
+declare -r sbt_launch_ivy_release_repo="http://repo.typesafe.com/typesafe/ivy-releases"
+declare -r sbt_launch_ivy_snapshot_repo="https://repo.scala-sbt.org/scalasbt/ivy-snapshots"
+declare -r sbt_launch_mvn_release_repo="http://repo.scala-sbt.org/scalasbt/maven-releases"
+declare -r sbt_launch_mvn_snapshot_repo="http://repo.scala-sbt.org/scalasbt/maven-snapshots"
+
+declare -r default_jvm_opts_common="-Xms512m -Xmx1536m -Xss2m"
+declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
+
+declare sbt_jar sbt_dir sbt_create sbt_version sbt_script sbt_new
+declare sbt_explicit_version
+declare verbose noshare batch trace_level
 declare sbt_saved_stty debugUs
+
+declare java_cmd="java"
+declare sbt_launch_dir="$HOME/.sbt/launchers"
+declare sbt_launch_repo
+
+# pull -J and -D options to give to java.
+declare -a java_args scalac_args sbt_commands residual_args
+
+# args to jvm/sbt via files or environment variables
+declare -a extra_jvm_opts extra_sbt_opts
 
 echoerr () { echo >&2 "$@"; }
 vlog ()    { [[ -n "$verbose" ]] && echoerr "$@"; }
+die ()     { echo "Aborting: $@" ; exit 1; }
 
-# spaces are possible, e.g. sbt.version = 0.13.0
+# restore stty settings (echo in particular)
+onSbtRunnerExit() {
+  [[ -n "$sbt_saved_stty" ]] || return
+  vlog ""
+  vlog "restoring stty: $sbt_saved_stty"
+  stty "$sbt_saved_stty"
+  unset sbt_saved_stty
+}
+
+# save stty and trap exit, to ensure echo is re-enabled if we are interrupted.
+trap onSbtRunnerExit EXIT
+sbt_saved_stty="$(stty -g 2>/dev/null)"
+vlog "Saved stty: $sbt_saved_stty"
+
+# this seems to cover the bases on OSX, and someone will
+# have to tell me about the others.
+get_script_path () {
+  local path="$1"
+  [[ -L "$path" ]] || { echo "$path" ; return; }
+
+  local target="$(readlink "$path")"
+  if [[ "${target:0:1}" == "/" ]]; then
+    echo "$target"
+  else
+    echo "${path%/*}/$target"
+  fi
+}
+
+declare -r script_path="$(get_script_path "$BASH_SOURCE")"
+declare -r script_name="${script_path##*/}"
+
+init_default_option_file () {
+  local overriding_var="${!1}"
+  local default_file="$2"
+  if [[ ! -r "$default_file" && "$overriding_var" =~ ^@(.*)$ ]]; then
+    local envvar_file="${BASH_REMATCH[1]}"
+    if [[ -r "$envvar_file" ]]; then
+      default_file="$envvar_file"
+    fi
+  fi
+  echo "$default_file"
+}
+
+declare sbt_opts_file="$(init_default_option_file SBT_OPTS .sbtopts)"
+declare jvm_opts_file="$(init_default_option_file JVM_OPTS .jvmopts)"
+
 build_props_sbt () {
   [[ -r "$buildProps" ]] && \
     grep '^sbt\.version' "$buildProps" | tr '=\r' ' ' | awk '{ print $2; }'
@@ -44,117 +117,47 @@ set_sbt_version () {
   export sbt_version
 }
 
-# restore stty settings (echo in particular)
-onSbtRunnerExit() {
-  [[ -n "$sbt_saved_stty" ]] || return
-  vlog ""
-  vlog "restoring stty: $sbt_saved_stty"
-  stty "$sbt_saved_stty"
-  unset sbt_saved_stty
-}
-
-# save stty and trap exit, to ensure echo is reenabled if we are interrupted.
-trap onSbtRunnerExit EXIT
-sbt_saved_stty="$(stty -g 2>/dev/null)"
-vlog "Saved stty: $sbt_saved_stty"
-
-# this seems to cover the bases on OSX, and someone will
-# have to tell me about the others.
-get_script_path () {
-  local path="$1"
-  [[ -L "$path" ]] || { echo "$path" ; return; }
-
-  local target="$(readlink "$path")"
-  if [[ "${target:0:1}" == "/" ]]; then
-    echo "$target"
-  else
-    echo "${path%/*}/$target"
-  fi
-}
-
-die() {
-  echo "Aborting: $@"
-  exit 1
-}
-
-make_url () {
-  version="$1"
+url_base () {
+  local version="$1"
 
   case "$version" in
-        0.7.*) echo "http://simple-build-tool.googlecode.com/files/sbt-launch-0.7.7.jar" ;;
-      0.10.* ) echo "$sbt_launch_repo/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
-    0.11.[12]) echo "$sbt_launch_repo/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
-            *) echo "$sbt_launch_repo/org.scala-sbt/sbt-launch/$version/sbt-launch.jar" ;;
+        0.7.*) echo "http://simple-build-tool.googlecode.com" ;;
+      0.10.* ) echo "$sbt_launch_ivy_release_repo" ;;
+    0.11.[12]) echo "$sbt_launch_ivy_release_repo" ;;
+    0.*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]) # ie "*-yyyymmdd-hhMMss"
+               echo "$sbt_launch_ivy_snapshot_repo" ;;
+          0.*) echo "$sbt_launch_ivy_release_repo" ;;
+    *-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]) # ie "*-yyyymmdd-hhMMss"
+               echo "$sbt_launch_mvn_snapshot_repo" ;;
+            *) echo "$sbt_launch_mvn_release_repo" ;;
   esac
 }
 
-init_default_option_file () {
-  local overriding_var="${!1}"
-  local default_file="$2"
-  if [[ ! -r "$default_file" && "$overriding_var" =~ ^@(.*)$ ]]; then
-    local envvar_file="${BASH_REMATCH[1]}"
-    if [[ -r "$envvar_file" ]]; then
-      default_file="$envvar_file"
-    fi
-  fi
-  echo "$default_file"
+make_url () {
+  local version="$1"
+
+  local base="${sbt_launch_repo:-$(url_base "$version")}"
+
+  case "$version" in
+        0.7.*) echo "$base/files/sbt-launch-0.7.7.jar" ;;
+      0.10.* ) echo "$base/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
+    0.11.[12]) echo "$base/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
+          0.*) echo "$base/org.scala-sbt/sbt-launch/$version/sbt-launch.jar" ;;
+            *) echo "$base/org/scala-sbt/sbt-launch/$version/sbt-launch.jar" ;;
+  esac
 }
 
-declare -r cms_opts="-XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
-declare -r jit_opts="-XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation"
-declare -r default_jvm_opts_common="-Xms512m -Xmx1536m -Xss2m $jit_opts $cms_opts"
-declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
-declare -r latest_28="2.8.2"
-declare -r latest_29="2.9.3"
-declare -r latest_210="2.10.5"
-declare -r latest_211="2.11.7"
-declare -r latest_212="2.12.0-M2"
+addJava ()     { vlog "[addJava] arg = '$1'"   ;     java_args+=("$1"); }
+addSbt ()      { vlog "[addSbt] arg = '$1'"    ;  sbt_commands+=("$1"); }
+addScalac ()   { vlog "[addScalac] arg = '$1'" ;   scalac_args+=("$1"); }
+addResidual () { vlog "[residual] arg = '$1'"  ; residual_args+=("$1"); }
 
-declare -r script_path="$(get_script_path "$BASH_SOURCE")"
-declare -r script_name="${script_path##*/}"
-
-# some non-read-onlies set with defaults
-declare java_cmd="java"
-declare sbt_opts_file="$(init_default_option_file SBT_OPTS .sbtopts)"
-declare jvm_opts_file="$(init_default_option_file JVM_OPTS .jvmopts)"
-declare sbt_launch_repo="http://repo.typesafe.com/typesafe/ivy-releases"
-
-# pull -J and -D options to give to java.
-declare -a residual_args
-declare -a java_args
-declare -a scalac_args
-declare -a sbt_commands
-
-# args to jvm/sbt via files or environment variables
-declare -a extra_jvm_opts extra_sbt_opts
-
-addJava () {
-  vlog "[addJava] arg = '$1'"
-  java_args+=("$1")
-}
-addSbt () {
-  vlog "[addSbt] arg = '$1'"
-  sbt_commands+=("$1")
-}
+addResolver () { addSbt "set resolvers += $1"; }
+addDebugger () { addJava "-Xdebug" ; addJava "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=$1"; }
 setThisBuild () {
   vlog "[addBuild] args = '$@'"
   local key="$1" && shift
   addSbt "set $key in ThisBuild := $@"
-}
-addScalac () {
-  vlog "[addScalac] arg = '$1'"
-  scalac_args+=("$1")
-}
-addResidual () {
-  vlog "[residual] arg = '$1'"
-  residual_args+=("$1")
-}
-addResolver () {
-  addSbt "set resolvers += $1"
-}
-addDebugger () {
-  addJava "-Xdebug"
-  addJava "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=$1"
 }
 setScalaVersion () {
   [[ "$1" == *"-SNAPSHOT" ]] && addResolver 'Resolver.sonatypeRepo("snapshots")'
@@ -162,36 +165,39 @@ setScalaVersion () {
 }
 setJavaHome () {
   java_cmd="$1/bin/java"
-  setThisBuild javaHome "Some(file(\"$1\"))"
+  setThisBuild javaHome "_root_.scala.Some(file(\"$1\"))"
   export JAVA_HOME="$1"
   export JDK_HOME="$1"
   export PATH="$JAVA_HOME/bin:$PATH"
 }
-setJavaHomeQuietly () {
-  addSbt warn
-  setJavaHome "$1"
-  addSbt info
+
+getJavaVersion() { "$1" -version 2>&1 | grep -E -e '(java|openjdk) version' | awk '{ print $3 }' | tr -d \"; }
+
+checkJava() {
+  # Warn if there is a Java version mismatch between PATH and JAVA_HOME/JDK_HOME
+
+  [[ -n "$JAVA_HOME" && -e "$JAVA_HOME/bin/java"     ]] && java="$JAVA_HOME/bin/java"
+  [[ -n "$JDK_HOME"  && -e "$JDK_HOME/lib/tools.jar" ]] && java="$JDK_HOME/bin/java"
+
+  if [[ -n "$java" ]]; then
+    pathJavaVersion=$(getJavaVersion java)
+    homeJavaVersion=$(getJavaVersion "$java")
+    if [[ "$pathJavaVersion" != "$homeJavaVersion" ]]; then
+      echoerr "Warning: Java version mismatch between PATH and JAVA_HOME/JDK_HOME, sbt will use the one in PATH"
+      echoerr "  Either: fix your PATH, remove JAVA_HOME/JDK_HOME or use -java-home"
+      echoerr "  java version from PATH:               $pathJavaVersion"
+      echoerr "  java version from JAVA_HOME/JDK_HOME: $homeJavaVersion"
+    fi
+  fi
 }
 
-# if set, use JDK_HOME/JAVA_HOME over java found in path
-if [[ -e "$JDK_HOME/lib/tools.jar" ]]; then
-  setJavaHomeQuietly "$JDK_HOME"
-elif [[ -e "$JAVA_HOME/bin/java" ]]; then
-  setJavaHomeQuietly "$JAVA_HOME"
-fi
-
-# directory to store sbt launchers
-declare sbt_launch_dir="$HOME/.sbt/launchers"
-[[ -d "$sbt_launch_dir" ]] || mkdir -p "$sbt_launch_dir"
-[[ -w "$sbt_launch_dir" ]] || sbt_launch_dir="$(mktemp -d -t sbt_extras_launchers.XXXXXX)"
-
 java_version () {
-  local version=$("$java_cmd" -version 2>&1 | grep -E -e '(java|openjdk) version' | awk '{ print $3 }' | tr -d \")
+  local version=$(getJavaVersion "$java_cmd")
   vlog "Detected Java version: $version"
   echo "${version:2:1}"
 }
 
-# MaxPermSize critical on pre-8 jvms but incurs noisy warning on 8+
+# MaxPermSize critical on pre-8 JVMs but incurs noisy warning on 8+
 default_jvm_opts () {
   local v="$(java_version)"
   if [[ $v -ge 8 ]]; then
@@ -228,12 +234,14 @@ execRunner () {
   exec "$@"
 }
 
-jar_url () {
-  make_url "$1"
-}
+jar_url ()  { make_url "$1"; }
+
+is_cygwin () [[ "$(uname -a)" == "CYGWIN"* ]]
 
 jar_file () {
-  echo "$sbt_launch_dir/$1/sbt-launch.jar"
+  is_cygwin \
+  && echo "$(cygpath -w $sbt_launch_dir/"$1"/sbt-launch.jar)" \
+  || echo "$sbt_launch_dir/$1/sbt-launch.jar"
 }
 
 download_url () {
@@ -248,19 +256,26 @@ download_url () {
     if which curl >/dev/null; then
       curl --fail --silent --location "$url" --output "$jar"
     elif which wget >/dev/null; then
-      wget --quiet -O "$jar" "$url"
+      wget -q -O "$jar" "$url"
     fi
   } && [[ -r "$jar" ]]
 }
 
 acquire_sbt_jar () {
-  sbt_url="$(jar_url "$sbt_version")"
-  sbt_jar="$(jar_file "$sbt_version")"
-
-  [[ -r "$sbt_jar" ]] || download_url "$sbt_url" "$sbt_jar"
+  {
+    sbt_jar="$(jar_file "$sbt_version")"
+    [[ -r "$sbt_jar" ]]
+  } || {
+    sbt_jar="$HOME/.ivy2/local/org.scala-sbt/sbt-launch/$sbt_version/jars/sbt-launch.jar"
+    [[ -r "$sbt_jar" ]]
+  } || {
+    sbt_jar="$(jar_file "$sbt_version")"
+    download_url "$(make_url "$sbt_version")" "$sbt_jar"
+  }
 }
 
 usage () {
+  set_sbt_version
   cat <<EOM
 Usage: $script_name [options]
 
@@ -291,14 +306,15 @@ runner with the -x option.
   -jvm-debug <port>  Turn on JVM debugging, open at the given port.
   -batch             Disable interactive mode
   -prompt <expr>     Set the sbt prompt; in expr, 's' is the State and 'e' is Extracted
+  -script <file>     Run the specified file as a scala script
 
   # sbt version (default: sbt.version from $buildProps if present, otherwise $sbt_release_version)
   -sbt-force-latest         force the use of the latest release of sbt: $sbt_release_version
   -sbt-version  <version>   use the specified version of sbt (default: $sbt_release_version)
   -sbt-dev                  use the latest pre-release version of sbt: $sbt_unreleased_version
   -sbt-jar      <path>      use the specified jar as the sbt launcher
-  -sbt-launch-dir <path>    directory to hold sbt launchers (default: ~/.sbt/launchers)
-  -sbt-launch-repo <url>    repo url for downloading sbt launcher jar (default: $sbt_launch_repo)
+  -sbt-launch-dir <path>    directory to hold sbt launchers (default: $sbt_launch_dir)
+  -sbt-launch-repo <url>    repo url for downloading sbt launcher jar (default: $(url_base "$sbt_version"))
 
   # scala version (default: as chosen by sbt)
   -28                       use $latest_28
@@ -332,8 +348,7 @@ runner with the -x option.
 EOM
 }
 
-process_args ()
-{
+process_args () {
   require_arg () {
     local type="$1"
     local opt="$2"
@@ -345,11 +360,11 @@ process_args ()
   }
   while [[ $# -gt 0 ]]; do
     case "$1" in
-          -h|-help) usage; exit 1 ;;
+          -h|-help) usage; exit 0 ;;
                 -v) verbose=true && shift ;;
-                -d) addSbt "--debug" && addSbt debug && shift ;;
-                -w) addSbt "--warn"  && addSbt warn  && shift ;;
-                -q) addSbt "--error" && addSbt error && shift ;;
+                -d) addSbt "--debug" && shift ;;
+                -w) addSbt "--warn"  && shift ;;
+                -q) addSbt "--error" && shift ;;
                 -x) debugUs=true && shift ;;
             -trace) require_arg integer "$1" "$2" && trace_level="$2" && shift 2 ;;
               -ivy) require_arg path "$1" "$2" && addJava "-Dsbt.ivy.home=$2" && shift 2 ;;
@@ -358,10 +373,11 @@ process_args ()
          -sbt-boot) require_arg path "$1" "$2" && addJava "-Dsbt.boot.directory=$2" && shift 2 ;;
           -sbt-dir) require_arg path "$1" "$2" && sbt_dir="$2" && shift 2 ;;
         -debug-inc) addJava "-Dxsbt.inc.debug=true" && shift ;;
-          -offline) addSbt "set offline := true" && shift ;;
+          -offline) addSbt "set offline in Global := true" && shift ;;
         -jvm-debug) require_arg port "$1" "$2" && addDebugger "$2" && shift 2 ;;
             -batch) batch=true && shift ;;
            -prompt) require_arg "expr" "$1" "$2" && setThisBuild shellPrompt "(s => { val e = Project.extract(s) ; $2 })" && shift 2 ;;
+           -script) require_arg file "$1" "$2" && sbt_script="$2" && addJava "-Dsbt.main.class=sbt.ScriptMain" && shift 2 ;;
 
        -sbt-create) sbt_create=true && shift ;;
           -sbt-jar) require_arg path "$1" "$2" && sbt_jar="$2" && shift 2 ;;
@@ -372,7 +388,7 @@ process_args ()
   -sbt-launch-repo) require_arg path "$1" "$2" && sbt_launch_repo="$2" && shift 2 ;;
     -scala-version) require_arg version "$1" "$2" && setScalaVersion "$2" && shift 2 ;;
    -binary-version) require_arg version "$1" "$2" && setThisBuild scalaBinaryVersion "\"$2\"" && shift 2 ;;
-       -scala-home) require_arg path "$1" "$2" && setThisBuild scalaHome "Some(file(\"$2\"))" && shift 2 ;;
+       -scala-home) require_arg path "$1" "$2" && setThisBuild scalaHome "_root_.scala.Some(file(\"$2\"))" && shift 2 ;;
         -java-home) require_arg path "$1" "$2" && setJavaHome "$2" && shift 2 ;;
          -sbt-opts) require_arg path "$1" "$2" && sbt_opts_file="$2" && shift 2 ;;
          -jvm-opts) require_arg path "$1" "$2" && jvm_opts_file="$2" && shift 2 ;;
@@ -385,10 +401,7 @@ process_args ()
               -210) setScalaVersion "$latest_210" && shift ;;
               -211) setScalaVersion "$latest_211" && shift ;;
               -212) setScalaVersion "$latest_212" && shift ;;
-
-           --debug) addSbt debug && addResidual "$1" && shift ;;
-            --warn) addSbt warn  && addResidual "$1" && shift ;;
-           --error) addSbt error && addResidual "$1" && shift ;;
+               new) sbt_new=true && sbt_explicit_version="$sbt_release_version"  && addResidual "$1" && shift ;;
                  *) addResidual "$1" && shift ;;
     esac
   done
@@ -399,8 +412,10 @@ process_args "$@"
 
 # skip #-styled comments and blank lines
 readConfigFile() {
-  while read line; do
-    [[ $line =~ ^# ]] || [[ -z $line ]] || echo "$line"
+  local end=false
+  until $end; do
+    read || end=true
+    [[ $REPLY =~ ^# ]] || [[ -z $REPLY ]] || echo "$REPLY"
   done < "$1"
 }
 
@@ -425,6 +440,8 @@ argumentCount=$#
 # set sbt version
 set_sbt_version
 
+checkJava
+
 # only exists in 0.12+
 setTraceLevel() {
   case "$sbt_version" in
@@ -437,19 +454,21 @@ setTraceLevel() {
 [[ ${#scalac_args[@]} -eq 0 ]] || addSbt "set scalacOptions in ThisBuild += \"${scalac_args[@]}\""
 
 # Update build.properties on disk to set explicit version - sbt gives us no choice
-[[ -n "$sbt_explicit_version" ]] && update_build_props_sbt "$sbt_explicit_version"
+[[ -n "$sbt_explicit_version" && -z "$sbt_new" ]] && update_build_props_sbt "$sbt_explicit_version"
 vlog "Detected sbt version $sbt_version"
 
-[[ -n "$scala_version" ]] && vlog "Overriding scala version to $scala_version"
+if [[ -n "$sbt_script" ]]; then
+  residual_args=( $sbt_script ${residual_args[@]} )
+else
+  # no args - alert them there's stuff in here
+  (( argumentCount > 0 )) || {
+    vlog "Starting $script_name: invoke with -help for other options"
+    residual_args=( shell )
+  }
+fi
 
-# no args - alert them there's stuff in here
-(( argumentCount > 0 )) || {
-  vlog "Starting $script_name: invoke with -help for other options"
-  residual_args=( shell )
-}
-
-# verify this is an sbt dir or -create was given
-[[ -r ./build.sbt || -d ./project || -n "$sbt_create" ]] || {
+# verify this is an sbt dir, -create was given or user attempts to run a scala script
+[[ -r ./build.sbt || -d ./project || -n "$sbt_create" || -n "$sbt_script" || -n "$sbt_new" ]] || {
   cat <<EOM
 $(pwd) doesn't appear to be an sbt project.
 If you want to start sbt anyway, run:
@@ -461,6 +480,10 @@ EOM
 
 # pick up completion if present; todo
 [[ -r .sbt_completion.sh ]] && source .sbt_completion.sh
+
+# directory to store sbt launchers
+[[ -d "$sbt_launch_dir" ]] || mkdir -p "$sbt_launch_dir"
+[[ -w "$sbt_launch_dir" ]] || sbt_launch_dir="$(mktemp -d -t sbt_extras_launchers.XXXXXX)"
 
 # no jar? download it.
 [[ -r "$sbt_jar" ]] || acquire_sbt_jar || {
@@ -523,8 +546,8 @@ mainFiltered () {
 
   echoLine () {
     local line="$1"
-    local line1="$(echo "$line" | sed -r 's/\r\x1BM\x1B\[2K//g')"       # This strips the OverwriteLine code.
-    local line2="$(echo "$line1" | sed -r 's/\x1B\[[0-9;]*[JKmsu]//g')" # This strips all codes - we test regexes against this.
+    local line1="$(echo "$line" | sed 's/\r\x1BM\x1B\[2K//g')"       # This strips the OverwriteLine code.
+    local line2="$(echo "$line1" | sed 's/\x1B\[[0-9;]*[JKmsu]//g')" # This strips all codes - we test regexes against this.
 
     if [[ $line2 =~ $excludeRegex ]]; then
       [[ -n $debugUs ]] && echo "[X] $line1"


### PR DESCRIPTION
-- IOMetadata for passing data between operators at designtime.
-- Adding doubleToString method to SQLGenerator, as Teradata has restrictions on the number of digits (and using this for some models, will follow up with the complete list later).
-- Refinements / work on ChorusAPICaller.
-- JavascriptVisualModel, allowing operators to use their own Javascript for output visualization.
-- Updating sbt version.

@emiliedelongueau. These are the changes going into the next SDK.