### PR TITLE
Changes for the 1.9-beta version of the SDK (For Chorus 6.3).

### DIFF
--- a/alpine-model-api/src/main/scala/com/alpine/metadata/TransformationSchema.scala
+++ b/alpine-model-api/src/main/scala/com/alpine/metadata/TransformationSchema.scala
@@ -19,9 +19,10 @@ class TransformationSchema(val outputFeatures: Seq[ColumnDef], val identifier: S
   * If the user provides us with the input feature descriptions, then in the Predictor we will be able to verify that
   * the data set for prediction contains all the necessary columns at design-time (not currently implemented but should be easy to do).
   */
-case class DetailedTransformationSchema(inputFeatures: Seq[ColumnDef],
-                                        override val outputFeatures: Seq[ColumnDef],
-                                        override val identifier: String = "")
+case class DetailedTransformationSchema(
+  inputFeatures: Seq[ColumnDef],
+  override val outputFeatures: Seq[ColumnDef],
+  override val identifier: String = "")
   extends TransformationSchema(outputFeatures, identifier)
 
 trait RowModelMetadata extends IOMetadata {
@@ -33,15 +34,16 @@ trait RowModelMetadata extends IOMetadata {
 
 }
 
-case class RowModelMetadataDefault(transformationSchema: TransformationSchema,
-                                   sqlScorable: Boolean,
-                                   sqlOutputFeatures: Seq[ColumnDef]
-                                  ) extends RowModelMetadata
+case class RowModelMetadataDefault(
+  transformationSchema: TransformationSchema,
+  sqlScorable: Boolean,
+  sqlOutputFeatures: Seq[ColumnDef]
+) extends RowModelMetadata
 
 class ClassificationModelMetadata(inputFeatures: Option[Seq[ColumnDef]],
-                                  identifier: String,
-                                  val sqlScorable: Boolean,
-                                  val dependentColumn: Option[ColumnDef]) extends RowModelMetadata {
+  identifier: String,
+  val sqlScorable: Boolean,
+  val dependentColumn: Option[ColumnDef]) extends RowModelMetadata {
   override def transformationSchema: TransformationSchema = {
     inputFeatures match {
       case Some(f) => DetailedTransformationSchema(inputFeatures = f, outputFeatures = FeatureUtil.classificationOutputFeatures, identifier)
@@ -52,10 +54,11 @@ class ClassificationModelMetadata(inputFeatures: Option[Seq[ColumnDef]],
   override def sqlOutputFeatures: Seq[ColumnDef] = FeatureUtil.simpleModelOutputFeatures
 }
 
-class RegressionModelMetadata(inputFeatures: Option[Seq[ColumnDef]],
-                              identifier: String,
-                              val sqlScorable: Boolean,
-                              val dependentColumn: Option[ColumnDef]) extends RowModelMetadata {
+class RegressionModelMetadata(
+  inputFeatures: Option[Seq[ColumnDef]],
+  identifier: String,
+  val sqlScorable: Boolean,
+  val dependentColumn: Option[ColumnDef]) extends RowModelMetadata {
   override def transformationSchema: TransformationSchema = {
     inputFeatures match {
       case Some(f) => DetailedTransformationSchema(inputFeatures = f, outputFeatures = FeatureUtil.regressionOutputFeatures, identifier)
@@ -66,9 +69,10 @@ class RegressionModelMetadata(inputFeatures: Option[Seq[ColumnDef]],
   override def sqlOutputFeatures: Seq[ColumnDef] = FeatureUtil.regressionOutputFeatures
 }
 
-class ClusteringModelMetadata(inputFeatures: Option[Seq[ColumnDef]],
-                              identifier: String,
-                              val sqlScorable: Boolean) extends RowModelMetadata {
+class ClusteringModelMetadata(
+  inputFeatures: Option[Seq[ColumnDef]],
+  identifier: String,
+  val sqlScorable: Boolean) extends RowModelMetadata {
   override def transformationSchema: TransformationSchema = {
     inputFeatures match {
       case Some(f) => DetailedTransformationSchema(inputFeatures = f, outputFeatures = FeatureUtil.classificationOutputFeatures, identifier)

--- a/alpine-model-api/src/test/scala/com/alpine/util/SimpleSQLGenerator.scala
+++ b/alpine-model-api/src/test/scala/com/alpine/util/SimpleSQLGenerator.scala
@@ -14,9 +14,9 @@ import com.alpine.sql.{DatabaseType, SQLGenerator}
   */
 class SimpleSQLGenerator extends SQLGenerator {
 
-  private var databaseType:    TypeValue = postgres
-  private var quoteString:     String    = "\""
-  private var isAliasRequired: Boolean   = true
+  private var databaseType: TypeValue = postgres
+  private var quoteString: String = "\""
+  private var isAliasRequired: Boolean = true
 
   // single arg constructor for DatabaseType
   def this(dbType: TypeValue) = {
@@ -30,6 +30,7 @@ class SimpleSQLGenerator extends SQLGenerator {
   override def dbType: TypeValue = databaseType
 
   override def quoteChar: String = quoteString
+
   override def useAliasForSelectSubQueries: Boolean = isAliasRequired
 
   @deprecated("Please use quoteIdentifier instead [Paul]", "2016-04-22")
@@ -40,7 +41,7 @@ class SimpleSQLGenerator extends SQLGenerator {
   override def quoteObjectName(schemaName: String, objectName: String): String = {
     schemaName match {
       case null | "" => quoteIdentifier(objectName)
-      case _         => quoteIdentifier(schemaName) + "." + quoteIdentifier(objectName)
+      case _ => quoteIdentifier(schemaName) + "." + quoteIdentifier(objectName)
     }
   }
 

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/CastExpressions.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/CastExpressions.scala
@@ -1,0 +1,59 @@
+package com.alpine.model.pack.ast.expressions
+import com.alpine.common.serialization.json.TypeWrapper
+import com.alpine.sql.SQLGenerator
+import com.alpine.transformer.sql.ColumnarSQLExpression
+
+/**
+  * Created by meganchanglee on 6/26/17.
+  */
+
+
+abstract class CastExpression extends ASTExpression {
+  override def inputNames: Set[String] = Set()
+}
+
+case class CastAsDoubleExpression(arg: TypeWrapper[ASTExpression]) extends CastExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    val x = arg.execute(input)
+    x match {
+      case x: Number => x.doubleValue()
+      case x: String => x.toDouble
+      case null => null
+      case _ => Double.NaN
+    }
+  }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"CAST(${arg.toColumnarSQL(sqlGenerator: SQLGenerator).sql} AS DOUBLE)")
+  }
+}
+
+case class CastAsIntegerExpression(arg: TypeWrapper[ASTExpression]) extends CastExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    val x = arg.execute(input)
+    x match {
+      case x: Number => x.intValue()
+      case x: String => x.toInt
+      case null => null
+    }
+  }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"CAST(${arg.toColumnarSQL(sqlGenerator: SQLGenerator).sql} AS INTEGER)")
+  }
+}
+
+case class CastAsLongExpression(arg: TypeWrapper[ASTExpression]) extends CastExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    val x = arg.execute(input)
+    x match {
+      case x: Number => x.longValue()
+      case x: String => x.toLong
+      case _ => null
+    }
+  }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"CAST(${arg.toColumnarSQL(sqlGenerator: SQLGenerator).sql} AS LONG)")
+  }
+}

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/ComparisonExpressions.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/ComparisonExpressions.scala
@@ -4,6 +4,8 @@
 package com.alpine.model.pack.ast.expressions
 
 import com.alpine.common.serialization.json.TypeWrapper
+import com.alpine.sql.SQLGenerator
+import com.alpine.transformer.sql.ColumnarSQLExpression
 
 /**
   * Created by Jennifer Thompson on 2/23/17.
@@ -16,6 +18,12 @@ case class GreaterThanExpression(left: TypeWrapper[ASTExpression], right: TypeWr
       case _ => null
     }
   }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val leftAsSQL = left.toColumnarSQL(sqlGenerator).sql
+    val rightAsSQL = right.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"($leftAsSQL) > ($rightAsSQL)")
+  }
 }
 
 case class GreaterThanOrEqualsExpression(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
@@ -25,6 +33,12 @@ case class GreaterThanOrEqualsExpression(left: TypeWrapper[ASTExpression], right
       case (x: Number, y: Number) => x.doubleValue() >= y.doubleValue()
       case _ => null
     }
+  }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val leftAsSQL = left.toColumnarSQL(sqlGenerator).sql
+    val rightAsSQL = right.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"($leftAsSQL) >= ($rightAsSQL)")
   }
 }
 
@@ -36,6 +50,12 @@ case class LessThanExpression(left: TypeWrapper[ASTExpression], right: TypeWrapp
       case _ => null
     }
   }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val leftAsSQL = left.toColumnarSQL(sqlGenerator).sql
+    val rightAsSQL = right.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"($leftAsSQL) < ($rightAsSQL)")
+  }
 }
 
 case class LessThanOrEqualsExpression(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
@@ -46,18 +66,30 @@ case class LessThanOrEqualsExpression(left: TypeWrapper[ASTExpression], right: T
       case _ => null
     }
   }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val leftAsSQL = left.toColumnarSQL(sqlGenerator).sql
+    val rightAsSQL = right.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"($leftAsSQL) <= ($rightAsSQL)")
+  }
 }
 
 class BetweenExpression(val value: TypeWrapper[ASTExpression], val min: TypeWrapper[ASTExpression], val max: TypeWrapper[ASTExpression])
   extends ASTExpression {
   @transient lazy val inputNames: Set[String] = value.inputNames ++ min.inputNames ++ max.inputNames
-
   override def execute(input: Map[String, Any]): Any = {
     (value.execute(input), min.execute(input), max.execute(input)) match {
       case (v: Number, minimum: Number, maximum: Number) =>
         v.doubleValue() >= minimum.doubleValue() && maximum.doubleValue() >= v.doubleValue()
       case _ => null
     }
+  }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val minAsSQL = min.toColumnarSQL(sqlGenerator).sql
+    val maxAsSQL = max.toColumnarSQL(sqlGenerator).sql
+    val valueAsSQL = value.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"($valueAsSQL) BETWEEN ($minAsSQL) AND ($maxAsSQL)")
   }
 }
 
@@ -66,12 +98,24 @@ case class EqualsExpression(left: TypeWrapper[ASTExpression], right: TypeWrapper
   override def executeForNonNullValues(leftVal: Any, rightVal: Any): Any = {
     leftVal == rightVal
   }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val leftAsSQL = left.toColumnarSQL(sqlGenerator).sql
+    val rightAsSQL = right.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"($leftAsSQL) = ($rightAsSQL)")
+  }
 }
 
 case class NotEqualsExpression(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
   extends BinaryASSTExpressionWithNullHandling {
   override def executeForNonNullValues(leftVal: Any, rightVal: Any): Any = {
     leftVal != rightVal
+  }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val leftAsSQL = left.toColumnarSQL(sqlGenerator).sql
+    val rightAsSQL = right.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"($leftAsSQL) <> ($rightAsSQL)")
   }
 }
 
@@ -81,5 +125,26 @@ case class IsDistinctFromExpression(left: TypeWrapper[ASTExpression], right: Typ
     val leftVal = left.execute(input)
     val rightVal = right.execute(input)
     leftVal != rightVal
+  }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val leftAsSQL = left.toColumnarSQL(sqlGenerator).sql
+    val rightAsSQL = right.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"($leftAsSQL) IS DISTINCT FROM ($rightAsSQL)")
+  }
+}
+
+case class IsNotDistinctFromExpression(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
+  extends BinaryASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    val leftVal = left.execute(input)
+    val rightVal = right.execute(input)
+    leftVal == rightVal
+  }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val leftAsSQL = left.toColumnarSQL(sqlGenerator).sql
+    val rightAsSQL = right.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"($leftAsSQL) IS NOT DISTINCT FROM ($rightAsSQL)")
   }
 }

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/LiteralExpressions.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/LiteralExpressions.scala
@@ -2,6 +2,9 @@
  * COPYRIGHT (C) 2017 Alpine Data Labs Inc. All Rights Reserved.
 */
 package com.alpine.model.pack.ast.expressions
+import com.alpine.sql.SQLGenerator
+import com.alpine.transformer.sql.ColumnarSQLExpression
+import com.alpine.util.SQLUtility
 
 
 /**
@@ -13,20 +16,41 @@ abstract class LiteralExpression extends ASTExpression {
 
 case class LongLiteralExpression(l: Long) extends LiteralExpression {
   override def execute(input: Map[String, Any]): Long = l
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(l.toString)
+  }
 }
 
 case class StringLiteralExpression(s: String) extends LiteralExpression {
   override def execute(input: Map[String, Any]): String = s
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(SQLUtility.wrapInSingleQuotes(s))
+  }
 }
 
 case class DoubleLiteralExpression(d: Double) extends LiteralExpression {
   override def execute(input: Map[String, Any]): Double = d
+
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(d.toString)
+  }
 }
 
 case class BooleanLiteralExpression(boolean: Boolean) extends LiteralExpression {
   override def execute(input: Map[String, Any]): Boolean = boolean
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(boolean.toString)
+  }
 }
 
 case class NullLiteralExpression() extends LiteralExpression {
   override def execute(input: Map[String, Any]): Any = null
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression("NULL")
+  }
 }

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/MathExpressions.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/MathExpressions.scala
@@ -4,6 +4,8 @@
 package com.alpine.model.pack.ast.expressions
 
 import com.alpine.common.serialization.json.TypeWrapper
+import com.alpine.sql.SQLGenerator
+import com.alpine.transformer.sql.ColumnarSQLExpression
 
 /**
   * Created by Jennifer Thompson on 2/23/17.
@@ -16,6 +18,12 @@ case class AddFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTE
       case _ => null
     }
   }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val leftAsSQL = left.toColumnarSQL(sqlGenerator).sql
+    val rightAsSQL = right.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"($leftAsSQL) + ($rightAsSQL) ")
+  }
 }
 
 case class SubtractFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
@@ -26,6 +34,12 @@ case class SubtractFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper
       case _ => null
     }
   }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val leftAsSQL = left.toColumnarSQL(sqlGenerator).sql
+    val rightAsSQL = right.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"($leftAsSQL) - ($rightAsSQL)")
+  }
 }
 
 case class MultiplyFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
@@ -35,6 +49,12 @@ case class MultiplyFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper
       case (x: Number, y: Number) => x.doubleValue() * y.doubleValue()
       case _ => null
     }
+  }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val leftAsSQL = left.toColumnarSQL(sqlGenerator).sql
+    val rightAsSQL = right.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"($leftAsSQL) * ($rightAsSQL)")
   }
 }
 
@@ -50,6 +70,12 @@ case class DivideFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[A
       case _ => null
     }
   }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val leftAsSQL = left.toColumnarSQL(sqlGenerator).sql
+    val rightAsSQL = right.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"($leftAsSQL) / ($rightAsSQL)")
+  }
 }
 
 case class ModulusFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
@@ -60,6 +86,12 @@ case class ModulusFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[
       case _ => null
     }
   }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val leftAsSQL = left.toColumnarSQL(sqlGenerator).sql
+    val rightAsSQL = right.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"MOD($leftAsSQL, $rightAsSQL)")
+  }
 }
 
 case class PowerFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
@@ -69,6 +101,12 @@ case class PowerFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[AS
       case (x: Number, y: Number) => math.pow(x.doubleValue(), y.doubleValue())
       case _ => null
     }
+  }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val leftAsSQL = left.toColumnarSQL(sqlGenerator).sql
+    val rightAsSQL = right.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"POWER($leftAsSQL, $rightAsSQL)")
   }
 }
 
@@ -86,36 +124,121 @@ abstract class SingleArgumentDoubleFunction extends SingleArgumentASSTExpression
 
 case class ExpFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
   override def function: Double => Double = math.exp
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"EXP(${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
 }
 
 case class SqrtFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
   override def function: Double => Double = math.sqrt
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"SQRT(${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
 }
 
 case class CbrtFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
   override def function: Double => Double = math.cbrt
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"CBRT(${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
 }
 
 case class NegativeFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
   override def function: Double => Double = x => (-1) * x
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"- (${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
 }
 
 case class AbsoluteValueFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
   override def function: Double => Double = math.abs
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"ABS(${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
 }
 
 case class CeilingFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
   override def function: Double => Double = math.ceil
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    // Could alternatively use CEIL, but it is less widely supported.
+    ColumnarSQLExpression(s"CEILING(${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
 }
 
 case class FloorFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
   override def function: Double => Double = math.floor
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"FLOOR(${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
 }
 
 case class NaturalLogFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
   override def function: Double => Double = math.log
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"LN(${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
 }
 
 case class Log10Function(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
   override def function: Double => Double = math.log10
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"LOG(${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
+}
+
+case class CosineFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
+  override def function: Double => Double = math.cos
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"COS(${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
+}
+
+case class SineFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
+  override def function: Double => Double = math.sin
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"SIN(${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
+}
+
+case class TangentFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
+  override def function: Double => Double = math.tan
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"TAN(${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
+}
+
+case class InverseSineFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
+  override def function: Double => Double = math.asin
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"ASIN(${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
+}
+
+case class InverseCosineFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
+  override def function: Double => Double = math.acos
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"ACOS(${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
+}
+
+case class InverseTangentFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentDoubleFunction {
+  override def function: Double => Double = math.atan
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"ATAN(${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
 }

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/NullHandlingExpressions.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/NullHandlingExpressions.scala
@@ -4,6 +4,8 @@
 package com.alpine.model.pack.ast.expressions
 
 import com.alpine.common.serialization.json.TypeWrapper
+import com.alpine.sql.SQLGenerator
+import com.alpine.transformer.sql.ColumnarSQLExpression
 
 /**
   * https://www.postgresql.org/docs/8.4/static/functions-conditional.html
@@ -11,7 +13,6 @@ import com.alpine.common.serialization.json.TypeWrapper
   */
 case class CoalesceFunction(arguments: Seq[TypeWrapper[ASTExpression]]) extends ASTExpression {
   override def inputNames: Set[String] = arguments.flatMap(_.inputNames).toSet
-
   override def execute(input: Map[String, Any]): Any = {
     var result: Any = null
     val i = arguments.iterator
@@ -20,17 +21,30 @@ case class CoalesceFunction(arguments: Seq[TypeWrapper[ASTExpression]]) extends 
     }
     result
   }
-}
 
-case class IsNotNullExpression(argument: TypeWrapper[ASTExpression]) extends SingleArgumentASSTExpression {
-  override def execute(input: Map[String, Any]): Any = {
-    argument.execute(input) != null
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val inner = arguments.map { a => a.value.toColumnarSQL(sqlGenerator).sql }.mkString(", ")
+    ColumnarSQLExpression(s"COALESCE($inner)")
   }
 }
 
 case class IsNullExpression(argument: TypeWrapper[ASTExpression]) extends SingleArgumentASSTExpression {
   override def execute(input: Map[String, Any]): Any = {
     argument.execute(input) == null
+  }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"(${argument.toColumnarSQL(sqlGenerator).sql}) IS NULL")
+  }
+}
+
+case class IsNotNullExpression(argument: TypeWrapper[ASTExpression]) extends SingleArgumentASSTExpression {
+  override def execute(input: Map[String, Any]): Any = {
+    argument.execute(input) != null
+  }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"(${argument.toColumnarSQL(sqlGenerator).sql}) IS NOT NULL")
   }
 }
 
@@ -43,5 +57,11 @@ case class NullIfFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[A
     } else {
       leftVal
     }
+  }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val leftAsSQL = left.toColumnarSQL(sqlGenerator).sql
+    val rightAsSQL = right.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"NULLIF($leftAsSQL, $rightAsSQL)")
   }
 }

--- a/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/StringExpressions.scala
+++ b/alpine-model-pack/src/main/scala/com/alpine/model/pack/ast/expressions/StringExpressions.scala
@@ -4,6 +4,8 @@
 package com.alpine.model.pack.ast.expressions
 
 import com.alpine.common.serialization.json.TypeWrapper
+import com.alpine.sql.{DatabaseType, SQLGenerator}
+import com.alpine.transformer.sql.ColumnarSQLExpression
 
 /**
   * Created by Jennifer Thompson on 2/23/17.
@@ -17,6 +19,10 @@ case class ToUpperCaseFunction(argument: TypeWrapper[ASTExpression]) extends Sin
       argVal.toString.toUpperCase
     }
   }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"UPPER(${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
 }
 
 case class ToLowerCaseFunction(argument: TypeWrapper[ASTExpression]) extends SingleArgumentASSTExpression {
@@ -27,6 +33,10 @@ case class ToLowerCaseFunction(argument: TypeWrapper[ASTExpression]) extends Sin
     } else {
       argVal.toString.toLowerCase
     }
+  }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    ColumnarSQLExpression(s"LOWER(${argument.toColumnarSQL(sqlGenerator).sql})")
   }
 }
 
@@ -39,11 +49,28 @@ case class StringLengthFunction(argument: TypeWrapper[ASTExpression]) extends Si
       argVal.toString.length
     }
   }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val lengthFunctionName = {
+      if (sqlGenerator.dbType == DatabaseType.greenplum) {
+        "LEN"
+      } else {
+        "LENGTH"
+      }
+    }
+    ColumnarSQLExpression(s"$lengthFunctionName(${argument.toColumnarSQL(sqlGenerator).sql})")
+  }
 }
 
 case class StringConcatenationFunction(left: TypeWrapper[ASTExpression], right: TypeWrapper[ASTExpression])
   extends BinaryASSTExpressionWithNullHandling {
   override def executeForNonNullValues(leftVal: Any, rightVal: Any): Any = {
     leftVal.toString + rightVal.toString
+  }
+
+  override def toColumnarSQL(sqlGenerator: SQLGenerator): ColumnarSQLExpression = {
+    val leftAsSQL = left.toColumnarSQL(sqlGenerator).sql
+    val rightAsSQL = right.toColumnarSQL(sqlGenerator).sql
+    ColumnarSQLExpression(s"($leftAsSQL) || ($rightAsSQL)")
   }
 }

--- a/alpine-model-pack/src/test/scala/com/alpine/model/pack/multiple/sql/GroupByClassificationSQLTransformerTest.scala
+++ b/alpine-model-pack/src/test/scala/com/alpine/model/pack/multiple/sql/GroupByClassificationSQLTransformerTest.scala
@@ -87,6 +87,7 @@ class GroupByClassificationSQLTransformerTest extends FunSuite {
     val model: RowModel = ModelJsonUtil.compactGsonBuilder.create().fromJson(GroupBySampleModels.model, classOf[TypeWrapper[RowModel]]).value
     val sql = model.sqlTransformer(simpleSQLGenerator).get.getSQL
     val selectStatement = SQLUtility.getSelectStatement(sql, "\"demo\".\"golfnew\"", new AliasGenerator(), simpleSQLGenerator)
+    // println(selectStatement)
 
     /**
       * There is redundancy in the SQL, which we should fix at some point.
@@ -94,9 +95,9 @@ class GroupByClassificationSQLTransformerTest extends FunSuite {
     val expectedSQL =
       """SELECT CASE WHEN "CONF0" IS NULL OR "CONF1" IS NULL
         |  THEN NULL
-        |        ELSE (CASE WHEN ("CONF0" > "CONF1")
-        |          THEN 'yes'
-        |              ELSE 'no' END) END AS "PRED"
+        |       ELSE (CASE WHEN ("CONF0" > "CONF1")
+        |         THEN 'yes'
+        |             ELSE 'no' END) END AS "PRED"
         |FROM (SELECT
         |        (CASE WHEN ("outlook" = 'overcast')
         |          THEN "CONF0"
@@ -115,78 +116,95 @@ class GroupByClassificationSQLTransformerTest extends FunSuite {
         |      FROM (SELECT
         |              "ce0"       AS "CONF0",
         |              "baseVal"   AS "CONF1",
-        |              "column_8"  AS "CONF0_1",
-        |              "column_9"  AS "CONF1_1",
-        |              "column_19" AS "CONF0_2",
-        |              "column_20" AS "CONF1_2",
+        |              "column_12" AS "CONF0_1",
+        |              "column_13" AS "CONF1_1",
+        |              "column_26" AS "CONF0_2",
+        |              "column_27" AS "CONF1_2",
         |              "column_0"  AS "outlook"
         |            FROM (SELECT
         |                    1 / "sum"                 AS "baseVal",
         |                    "e0" / "sum"              AS "ce0",
-        |                    1 / "column_6"            AS "column_9",
-        |                    "column_7" / "column_6"   AS "column_8",
-        |                    1 / "column_17"           AS "column_20",
-        |                    "column_18" / "column_17" AS "column_19",
+        |                    1 / "column_10"           AS "column_13",
+        |                    "column_11" / "column_10" AS "column_12",
+        |                    1 / "column_24"           AS "column_27",
+        |                    "column_25" / "column_24" AS "column_26",
         |                    "column_0"                AS "column_0"
         |                  FROM (SELECT
         |                          1 + "e0"        AS "sum",
         |                          "e0"            AS "e0",
-        |                          1 + "column_5"  AS "column_6",
-        |                          "column_5"      AS "column_7",
-        |                          1 + "column_16" AS "column_17",
-        |                          "column_16"     AS "column_18",
+        |                          1 + "column_9"  AS "column_10",
+        |                          "column_9"      AS "column_11",
+        |                          1 + "column_23" AS "column_24",
+        |                          "column_23"     AS "column_25",
         |                          "column_0"      AS "column_0"
         |                        FROM (SELECT
         |                                EXP(11.566053522376023 + "temperature" * 1.1368683772161603E-13 +
         |                                    "humidity" * 1.4210854715202004E-13 + "wind_0" * 3.637978807091713E-12 +
         |                                    "wind_1" * 0.0)    AS "e0",
-        |                                EXP(11.566053522373863 + "column_1" * -4.884981308350689E-15 +
-        |                                    "column_3" * 5.828670879282072E-16 + "column_4" * -23.132107044747375 +
-        |                                    "column_2" * 0.0)  AS "column_5",
-        |                                EXP(-4.217191318784561 + "column_12" * -0.022443258429683213 +
-        |                                    "column_14" * -0.052069985289528796 + "column_15" * 22.74983888277704 +
-        |                                    "column_13" * 0.0) AS "column_16",
+        |                                EXP(11.566053522373863 + "column_5" * -4.884981308350689E-15 +
+        |                                    "column_7" * 5.828670879282072E-16 + "column_8" * -23.132107044747375 +
+        |                                    "column_6" * 0.0)  AS "column_9",
+        |                                EXP(-4.217191318784561 + "column_19" * -0.022443258429683213 +
+        |                                    "column_21" * -0.052069985289528796 + "column_22" * 22.74983888277704 +
+        |                                    "column_20" * 0.0) AS "column_23",
         |                                "column_0"             AS "column_0"
         |                              FROM (SELECT
-        |                                      "temperature" AS "temperature",
-        |                                      "humidity"    AS "humidity",
+        |                                      "column_0"      AS "temperature",
+        |                                      "column_1"      AS "humidity",
         |                                      (CASE WHEN ("wind" = 'true')
         |                                        THEN 1
-        |                                       WHEN ("wind" = 'false')
+        |                                       WHEN "wind" IS NOT NULL
         |                                         THEN 0
         |                                       ELSE NULL END) AS "wind_0",
         |                                      (CASE WHEN ("wind" = 'false')
         |                                        THEN 1
-        |                                       WHEN ("wind" = 'true')
+        |                                       WHEN "wind" IS NOT NULL
         |                                         THEN 0
         |                                       ELSE NULL END) AS "wind_1",
-        |                                      "temperature"   AS "column_1",
-        |                                      "humidity"      AS "column_3",
-        |                                      (CASE WHEN ("wind" = 'true')
+        |                                      "column_3"      AS "column_5",
+        |                                      "column_2"      AS "column_7",
+        |                                      (CASE WHEN ("column_4" = 'true')
         |                                        THEN 1
-        |                                       WHEN ("wind" = 'false')
+        |                                       WHEN "column_4" IS NOT NULL
         |                                         THEN 0
-        |                                       ELSE NULL END) AS "column_4",
-        |                                      (CASE WHEN ("wind" = 'false')
+        |                                       ELSE NULL END) AS "column_8",
+        |                                      (CASE WHEN ("column_4" = 'false')
         |                                        THEN 1
-        |                                       WHEN ("wind" = 'true')
+        |                                       WHEN "column_4" IS NOT NULL
         |                                         THEN 0
-        |                                       ELSE NULL END) AS "column_2",
-        |                                      "temperature"   AS "column_12",
-        |                                      "humidity"      AS "column_14",
-        |                                      (CASE WHEN ("wind" = 'true')
+        |                                       ELSE NULL END) AS "column_6",
+        |                                      "column_17"     AS "column_19",
+        |                                      "column_16"     AS "column_21",
+        |                                      (CASE WHEN ("column_18" = 'true')
         |                                        THEN 1
-        |                                       WHEN ("wind" = 'false')
+        |                                       WHEN "column_18" IS NOT NULL
         |                                         THEN 0
-        |                                       ELSE NULL END) AS "column_15",
-        |                                      (CASE WHEN ("wind" = 'false')
+        |                                       ELSE NULL END) AS "column_22",
+        |                                      (CASE WHEN ("column_18" = 'false')
         |                                        THEN 1
-        |                                       WHEN ("wind" = 'true')
+        |                                       WHEN "column_18" IS NOT NULL
         |                                         THEN 0
-        |                                       ELSE NULL END) AS "column_13",
-        |                                      "outlook"     AS "column_0"
-        |                                    FROM
-        |                                      "demo"."golfnew") AS alias_0) AS alias_1) AS alias_2) AS alias_3) AS alias_4) AS alias_5"""
+        |                                       ELSE NULL END) AS "column_20",
+        |                                      "column_30"     AS "column_0"
+        |                                    FROM (SELECT
+        |                                            "temperature"   AS "column_0",
+        |                                            "humidity"      AS "column_1",
+        |                                            (CASE WHEN "wind" IN ('true', 'false')
+        |                                              THEN "wind"
+        |                                             ELSE NULL END) AS "wind",
+        |                                            "temperature"   AS "column_3",
+        |                                            "humidity"      AS "column_2",
+        |                                            (CASE WHEN "wind" IN ('true', 'false')
+        |                                              THEN "wind"
+        |                                             ELSE NULL END) AS "column_4",
+        |                                            "temperature"   AS "column_17",
+        |                                            "humidity"      AS "column_16",
+        |                                            (CASE WHEN "wind" IN ('true', 'false')
+        |                                              THEN "wind"
+        |                                             ELSE NULL END) AS "column_18",
+        |                                            "outlook"       AS "column_30"
+        |                                          FROM
+        |                                            "demo"."golfnew") AS alias_0) AS alias_1) AS alias_2) AS alias_3) AS alias_4) AS alias_5) AS alias_6"""
         .stripMargin.replaceAll("\\s+", " ").replaceAllLiterally("\n", "")
 
     assert(expectedSQL === selectStatement)

--- a/alpine-model-pack/src/test/scala/com/alpine/model/pack/multiple/sql/PipelineRegressionSQLTransformerTest.scala
+++ b/alpine-model-pack/src/test/scala/com/alpine/model/pack/multiple/sql/PipelineRegressionSQLTransformerTest.scala
@@ -5,8 +5,9 @@
 package com.alpine.model.pack.multiple.sql
 
 import com.alpine.model.pack.multiple.PipelineRowModelTest
+import com.alpine.model.pack.preprocess.OneHotEncodingModelTest
 import com.alpine.sql.AliasGenerator
-import com.alpine.transformer.sql.{ColumnName, ColumnarSQLExpression, RegressionModelSQLExpression}
+import com.alpine.transformer.sql.{ColumnarSQLExpression, RegressionModelSQLExpression}
 import com.alpine.util.{SQLUtility, SimpleSQLGenerator}
 import org.scalatest.FunSuite
 
@@ -21,13 +22,7 @@ class PipelineRegressionSQLTransformerTest extends FunSuite {
     val predictionSQL = sqlTransformer.getPredictionSQL
     val expected = RegressionModelSQLExpression(
       ColumnarSQLExpression("""0.0 + "outlook_0" * 0.9 + "outlook_1" * 1.0 + "wind_0" * 5.0"""),
-      List(
-        List(
-          (ColumnarSQLExpression("""(CASE WHEN ("outlook" = 'sunny') THEN 1 WHEN ("outlook" = 'overcast') OR ("outlook" = 'rain') THEN 0 ELSE NULL END)"""), ColumnName("outlook_0")),
-          (ColumnarSQLExpression("""(CASE WHEN ("outlook" = 'overcast') THEN 1 WHEN ("outlook" = 'sunny') OR ("outlook" = 'rain') THEN 0 ELSE NULL END)"""), ColumnName("outlook_1")),
-          (ColumnarSQLExpression("""(CASE WHEN ("wind" = 'true') THEN 1 WHEN ("wind" = 'false') THEN 0 ELSE NULL END)"""), ColumnName("wind_0"))
-        )
-      )
+      OneHotEncodingModelTest.expectedSQLExpressions.layers
     )
     assert(expected === predictionSQL)
   }
@@ -37,16 +32,33 @@ class PipelineRegressionSQLTransformerTest extends FunSuite {
     val sqlTransformer = model.sqlTransformer(new SimpleSQLGenerator).get
     val sqlExpressions = sqlTransformer.getSQL
     val selectStatement = SQLUtility.getSelectStatement(sqlExpressions, "demo.golfnew", new AliasGenerator(), new SimpleSQLGenerator)
+    // println(selectStatement)
     val expected =
-      """SELECT 0.0 +
-        | "outlook_0" * 0.9 + "outlook_1" * 1.0 + "wind_0" * 5.0 AS "PRED"
-        | FROM (SELECT
-        | (CASE WHEN ("outlook" = 'sunny') THEN 1 WHEN ("outlook" = 'overcast') OR ("outlook" = 'rain') THEN 0 ELSE NULL END) AS "outlook_0",
-        | (CASE WHEN ("outlook" = 'overcast') THEN 1 WHEN ("outlook" = 'sunny') OR ("outlook" = 'rain') THEN 0 ELSE NULL END) AS "outlook_1",
-        | (CASE WHEN ("wind" = 'true') THEN 1 WHEN ("wind" = 'false') THEN 0 ELSE NULL END) AS "wind_0"
-        | FROM demo.golfnew)
-        | AS alias_0
-        |""".stripMargin.replace("\n", "")
+      """SELECT 0.0 + "outlook_0" * 0.9 + "outlook_1" * 1.0 + "wind_0" * 5.0 AS "PRED"
+        |FROM (SELECT
+        |        (CASE WHEN ("outlook" = 'sunny')
+        |          THEN 1
+        |         WHEN "outlook" IS NOT NULL
+        |           THEN 0
+        |         ELSE NULL END) AS "outlook_0",
+        |        (CASE WHEN ("outlook" = 'overcast')
+        |          THEN 1
+        |         WHEN "outlook" IS NOT NULL
+        |           THEN 0
+        |         ELSE NULL END) AS "outlook_1",
+        |        (CASE WHEN ("wind" = 'true')
+        |          THEN 1
+        |         WHEN "wind" IS NOT NULL
+        |           THEN 0
+        |         ELSE NULL END) AS "wind_0"
+        |      FROM (SELECT
+        |              (CASE WHEN "outlook" IN ('sunny', 'overcast', 'rain')
+        |                THEN "outlook"
+        |               ELSE NULL END) AS "outlook",
+        |              (CASE WHEN "wind" IN ('true', 'false')
+        |                THEN "wind"
+        |               ELSE NULL END) AS "wind"
+        |            FROM demo.golfnew) AS alias_0) AS alias_1""".stripMargin.replaceAll("\\s+", " ").replace("\n", "")
     assert(expected === selectStatement)
   }
 

--- a/alpine-model-pack/src/test/scala/com/alpine/model/pack/multiple/sql/PipelineSQLTransformerTest.scala
+++ b/alpine-model-pack/src/test/scala/com/alpine/model/pack/multiple/sql/PipelineSQLTransformerTest.scala
@@ -9,7 +9,7 @@ import com.alpine.model.pack.multiple.PipelineRowModel
 import com.alpine.model.pack.preprocess.OneHotEncodingModelTest
 import com.alpine.sql.AliasGenerator
 import com.alpine.transformer.sql.{ColumnName, ColumnarSQLExpression, LayeredSQLExpressions}
-import com.alpine.util.{SimpleSQLGenerator, SQLUtility}
+import com.alpine.util.{SQLUtility, SimpleSQLGenerator}
 import org.scalatest.FunSuite
 
 /**
@@ -26,28 +26,26 @@ class PipelineSQLTransformerTest extends FunSuite {
     val pipe = PipelineRowModel(Seq(oneHotModel, linearRegressionModel)).sqlTransformer(simpleSQLGenerator).get
     val sqlExpr = pipe.getSQL
     val expected = LayeredSQLExpressions(
+      OneHotEncodingModelTest.expectedSQLExpressions.layers ++
       Seq(
-        List(
-          (ColumnarSQLExpression("""(CASE WHEN ("outlook" = 'sunny') THEN 1 WHEN ("outlook" = 'overcast') OR ("outlook" = 'rain') THEN 0 ELSE NULL END)"""), ColumnName("outlook_0")),
-          (ColumnarSQLExpression("""(CASE WHEN ("outlook" = 'overcast') THEN 1 WHEN ("outlook" = 'sunny') OR ("outlook" = 'rain') THEN 0 ELSE NULL END)"""), ColumnName("outlook_1")),
-          (ColumnarSQLExpression("""(CASE WHEN ("wind" = 'true') THEN 1 WHEN ("wind" = 'false') THEN 0 ELSE NULL END)"""), ColumnName("wind_0"))
-        ),
         Seq((ColumnarSQLExpression("0.2 + \"outlook_0\" * 0.9 + \"outlook_1\" * 1.0 + \"wind_0\" * 5.0"), ColumnName("PRED")))
       )
     )
     val createTableSQL = SQLUtility.createTable(sqlExpr, "demo.golfnew", "demo.delete_me", new AliasGenerator, new SimpleSQLGenerator)
+    // println(createTableSQL)
     val expectedSQL =
       """
         |CREATE TABLE demo.delete_me AS
         | SELECT
         | 0.2 + "outlook_0" * 0.9 + "outlook_1" * 1.0 + "wind_0" * 5.0 AS "PRED"
-        | FROM
-        | (SELECT
-        | (CASE WHEN ("outlook" = 'sunny') THEN 1 WHEN ("outlook" = 'overcast') OR ("outlook" = 'rain') THEN 0 ELSE NULL END) AS "outlook_0",
-        | (CASE WHEN ("outlook" = 'overcast') THEN 1 WHEN ("outlook" = 'sunny') OR ("outlook" = 'rain') THEN 0 ELSE NULL END) AS "outlook_1",
-        | (CASE WHEN ("wind" = 'true') THEN 1 WHEN ("wind" = 'false') THEN 0 ELSE NULL END) AS "wind_0"
-        | FROM demo.golfnew
-        |) AS alias_0
+        | FROM (SELECT
+        | (CASE WHEN ("outlook" = 'sunny') THEN 1 WHEN "outlook" IS NOT NULL THEN 0 ELSE NULL END) AS "outlook_0",
+        | (CASE WHEN ("outlook" = 'overcast') THEN 1 WHEN "outlook" IS NOT NULL THEN 0 ELSE NULL END) AS "outlook_1",
+        | (CASE WHEN ("wind" = 'true') THEN 1 WHEN "wind" IS NOT NULL THEN 0 ELSE NULL END) AS "wind_0"
+        | FROM (SELECT
+        | (CASE WHEN "outlook" IN ('sunny', 'overcast', 'rain') THEN "outlook" ELSE NULL END) AS "outlook",
+        | (CASE WHEN "wind" IN ('true', 'false') THEN "wind" ELSE NULL END) AS "wind"
+        | FROM demo.golfnew) AS alias_0) AS alias_1
         |""".stripMargin.replace("\n", "")
     assert(expected === sqlExpr)
     assert(expectedSQL === createTableSQL)

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,15 @@
+import sbtassembly.Plugin.AssemblyKeys._
 import sbtassembly.Plugin._
-import AssemblyKeys._
 //import com.typesafe.sbt.SbtGit.GitKeys
 
-val sdkVersion = "1.9-alpha-1"
-lazy val javaSourceVersion = "1.7"
-lazy val javaTargetVersion = "1.7"
-lazy val scalaMajorVersion = "2.10"
-lazy val sparkVersion = "1.6.1"
+val sdkVersion = "1.9-beta"
+val javaSourceVersion = "1.7"
+val javaTargetVersion = "1.7"
+val scalaMajorVersion = "2.10"
+val scalaFullVersion = "2.10.4"
+val sparkVersion = "1.6.1"
+
+scalaVersion := scalaFullVersion
 
 def publishParameters(module: String) = Seq(
   organization := "com.alpinenow",
@@ -30,6 +33,7 @@ def publishParameters(module: String) = Seq(
     val nexus = "https://oss.sonatype.org/"
     Some("releases" at nexus + "service/local/staging/deploy/maven2")
   },
+  scalaVersion := scalaFullVersion,
   licenses := Seq("Apache License 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
   scalacOptions in(Compile, doc) ++= Seq("-doc-footer", "Copyright (c) 2015 Alpine Data Labs."),
   javacOptions in compile ++= Seq("-source", javaSourceVersion, "-target", javaTargetVersion),
@@ -68,12 +72,12 @@ def sparkDependencies = excludeJPMML({
     "org.apache.spark" % s"spark-network-yarn_$scalaMajorVersion" % sparkVersion,
     "org.apache.spark" % s"spark-network-common_$scalaMajorVersion" % sparkVersion,
     "org.apache.spark" % s"spark-network-shuffle_$scalaMajorVersion" % sparkVersion,
-    "com.databricks" % "spark-avro_2.10" % "1.0.0",
-    "com.databricks" % "spark-csv_2.10" % "1.3.0"
+    "com.databricks" % s"spark-avro_$scalaMajorVersion" % "1.0.0",
+    "com.databricks" % s"spark-csv_$scalaMajorVersion" % "1.3.0"
   )
 })
 
-val scalaTestDep = "org.scalatest" % "scalatest_2.10" % "2.2.4"
+val scalaTestDep = "org.scalatest" % s"scalatest_$scalaMajorVersion" % "2.2.4"
 val gsonDependency = "com.google.code.gson" % "gson" % "2.3.1"
 val jodaTimeDependency = "joda-time" % "joda-time" % "2.1"
 val commonsIODependency = "commons-io" % "commons-io" % "2.4"
@@ -174,6 +178,7 @@ lazy val CompleteModule = Project(
   id = "alpine-complete-sdk",
   base = file("alpine-complete-sdk"), // Empty.
   settings = assemblySettings ++ Seq(
+    scalaVersion := scalaFullVersion,
     test in assembly := {},
     jarName in assembly := s"alpine-sdk-assembly-$sdkVersion.jar",
     mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) => {

--- a/common/src/main/scala/com/alpine/plugin/core/io/DataParser.scala
+++ b/common/src/main/scala/com/alpine/plugin/core/io/DataParser.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2015 Alpine Data Labs
+ * All rights reserved.
+ */
+package com.alpine.plugin.core.io
+
+import com.google.gson.GsonBuilder
+import com.google.gson.reflect.TypeToken
+import org.joda.time.DateTime
+import org.joda.time.format.{DateTimeFormat, DateTimeFormatter, ISODateTimeFormat}
+
+/**
+ * Interface used to define a parser,
+ * which must provide methods for taking
+ * a data type to and from String representation.
+ */
+trait DataParser[A] {
+
+  def fromString(s: String): A
+
+  def isValidString(s: String): Boolean
+
+  // Should only be called with Any of type A, but because we can't cast to a generic type at compile time, we use Any here.
+  def stringify(a: Any): String = a.toString
+
+}
+
+object ParserFactory {
+  def getParser(pluginType: ColumnType.TypeValue, format: Option[String] = None): DataParser[_] = {
+    pluginType match {
+      case ColumnType.String => StringParser
+      case ColumnType.Int => IntParser
+      case ColumnType.Long => LongParser
+      case ColumnType.Float => FloatParser
+      case ColumnType.Double => DoubleParser
+      case ColumnType.Boolean => BooleanParser
+      case ColumnType.DateTime => DateTimeParser(format)
+      case ColumnType.Sparse => MapStringDoubleParser
+    }
+  }
+}
+
+trait ParserWithTryCatch[A] extends DataParser[A] {
+  override def isValidString(s: String): Boolean = {
+    // I know we could use scala.util.Try, but I want to avoid the object creation.
+    try {
+      fromString(s)
+      true
+    }
+    catch {
+      case _: Exception => false
+    }
+  }
+}
+
+object DoubleParser extends ParserWithTryCatch[Double] {
+  override def fromString(s: String): Double = s.toDouble
+}
+
+object IntParser extends ParserWithTryCatch[Int] {
+  override def fromString(s: String): Int = s.toInt
+}
+
+object FloatParser extends ParserWithTryCatch[Float] {
+  override def fromString(s: String): Float = s.toFloat
+}
+
+object LongParser extends ParserWithTryCatch[Long] {
+  override def fromString(s: String): Long = s.toLong
+}
+
+object BooleanParser extends ParserWithTryCatch[Boolean] {
+  override def fromString(s: String): Boolean = s.toBoolean
+}
+
+object StringParser extends DataParser[String] {
+  override def fromString(s: String): String = s
+
+  override def isValidString(s: String): Boolean = true
+}
+
+case class DateTimeParser(format: Option[String] = None) extends ParserWithTryCatch[DateTime] {
+
+  val formatter: DateTimeFormatter = format match {
+    case Some(f) => DateTimeFormat.forPattern(f)
+    case None =>
+      // Consistent with the Pig ToDate function (lenient parsing)
+      // http://grepcode.com/file/repo1.maven.org/maven2/org.apache.pig/pig/0.12.0/org/apache/pig/builtin/ToDate.java#ToDate.0isoDateTimeFormatter
+      ISODateTimeFormat.dateOptionalTimeParser.withOffsetParsed
+  }
+
+  override def fromString(s: String): DateTime = formatter.parseDateTime(s)
+}
+
+object MapStringDoubleParser extends ParserWithTryCatch[java.util.Map[String, java.lang.Double]] {
+  private val t = new TypeToken[java.util.HashMap[String, java.lang.Double]]() {}.getType
+  private val gson = new GsonBuilder().serializeSpecialFloatingPointValues.create
+  override def fromString(s: String): java.util.HashMap[String, java.lang.Double] = {
+    gson.fromJson(s, t)
+  }
+
+  override def stringify(a: Any): String = {
+    gson.toJson(a)
+  }
+}

--- a/plugin-core/src/main/scala/com/alpine/plugin/OperatorDesignContext.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/OperatorDesignContext.scala
@@ -35,12 +35,13 @@ trait OperatorDesignContext {
   *                                  (filtered for hadoop or database depending on the operator runtime class)
   *                                  that could be used by the operator at runtime.
   */
-class OperatorDesignContextImpl(val inputMetadata: Map[OperatorInfo, IOMetadata],
-                                val parameters: OperatorParameters,
-                                val operatorDataSourceManager: OperatorDataSourceManager,
-                                val chorusAPICaller: ChorusAPICaller,
-                                val config: CustomOperatorConfig
-                               ) extends OperatorDesignContext {
+class OperatorDesignContextImpl(
+  val inputMetadata: Map[OperatorInfo, IOMetadata],
+  val parameters: OperatorParameters,
+  val operatorDataSourceManager: OperatorDataSourceManager,
+  val chorusAPICaller: ChorusAPICaller,
+  val config: CustomOperatorConfig
+) extends OperatorDesignContext {
   /**
     * Equivalent to the input schemas argument that used to be passed directly to the
     * onInputOrParameterChange of OperatorGUINode by the Alpine Engine.
@@ -69,6 +70,7 @@ trait TabularIOMetadata extends IOMetadata {
 
   def datasource: DataSource
 }
+
 /**
   * The default class for pass along TabularSchema and data-source information.
   *
@@ -76,8 +78,10 @@ trait TabularIOMetadata extends IOMetadata {
   * then we may wrap this in AugmentedTabularMetadata, if we can get the full TabularSchema
   * from step run results.
   */
-case class TabularIOMetadataDefault(tabularSchema: TabularSchema,
-                                    datasource: DataSource) extends TabularIOMetadata
+case class TabularIOMetadataDefault(
+  tabularSchema: TabularSchema,
+  datasource: DataSource
+) extends TabularIOMetadata
 
 /**
   * Used when the original metadata produced by the operator had a partial schema.
@@ -87,7 +91,9 @@ case class TabularIOMetadataDefault(tabularSchema: TabularSchema,
   * @param tabularSchema    TabularSchema from step run results.
   * @param originalMetadata Original Metadata, produced by the OperatorGUINode.
   */
-case class AugmentedTabularMetadata(tabularSchema: TabularSchema,
-                                    originalMetadata: TabularIOMetadata) extends TabularIOMetadata {
+case class AugmentedTabularMetadata(
+  tabularSchema: TabularSchema,
+  originalMetadata: TabularIOMetadata
+) extends TabularIOMetadata {
   override def datasource: DataSource = originalMetadata.datasource
 }

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/ChorusUserInfo.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/ChorusUserInfo.scala
@@ -17,9 +17,12 @@ case class ChorusUserInfo(userID: String, userName: String, sessionID: String)
   */
 case class WorkflowInfo(workflowID: String)
 
-case class NotebookDetails(readyToExecute: Boolean,
-                           inputMetadata: NotebookIOInfo,
-                           outputMetadata: NotebookIOInfo)
+
+case class NotebookDetails(readyToExecuteDB: Boolean,
+  readyToExecuteHD: Boolean,
+  useSpark: Boolean,
+  inputsMetadata: Map[String, NotebookIOInfo],
+  outputsMetadata: Map[String, NotebookIOInfo])
 
 
 case class PythonNotebook(chorusFile: ChorusFile,
@@ -34,4 +37,14 @@ case class PythonNotebookExecution(notebookId: String,
                                    error: Option[String],
                                    isFinished: Boolean)
 
-case class NotebookIOInfo(delimiter: String, quote: String, escape: String, columns: Seq[(String, String)])
+
+case class NotebookIOInfo(dataSourceName: String,
+  isHdfsInput: Boolean,
+  delimiter: String,
+  quote: String,
+  escape: String,
+  columns: Seq[(String, String)],
+  usesSpark: Boolean,
+  inputName: Option[String])
+
+case class ChorusDBSourceInfo(name: String, id: Int)

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/NotebookExecutionIO.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/NotebookExecutionIO.scala
@@ -1,0 +1,72 @@
+package com.alpine.plugin.core
+
+import java.util
+
+import com.alpine.plugin.core.utils.HdfsStorageFormatType
+
+/**
+  * Created by emiliedelongueau on 7/4/17.
+  */
+
+
+//classes to create the body of the runNotebookExecution api in ChorusAPICaller (for input(s) / output substitution)
+
+abstract class NotebookIOForExecution {
+  val executionLabel: String
+  def toBodyMap: java.util.HashMap[String, Any]
+}
+
+case class NotebookInputHDForExecution(executionLabel: String, path: String, header: Boolean, delimiter: Option[String], quote: Option[String],
+                                       escape: Option[String], columnNames: Seq[String], columnTypes: Seq[String]) extends NotebookIOForExecution {
+
+  def toBodyMap: util.HashMap[String, Any] = {
+    val map = new util.HashMap[String, Any]()
+    map.put("path", path)
+    map.put("header", header)
+    if (delimiter.isDefined) map.put("delimiter", delimiter.get)
+    if (quote.isDefined) map.put("quote", quote.get)
+    if (escape.isDefined) map.put("escape", escape.get)
+    map.put("column_names", columnNames.toArray)
+    map.put("column_types", columnTypes.toArray)
+
+    map
+  }
+}
+
+case class NotebookOutputHDForExecution(executionLabel: String, outputPath: String, delimiter: Option[String], quote: Option[String],
+                                        escape: Option[String], overwrite: Boolean, storageFormat: Option[String]) extends NotebookIOForExecution {
+
+  def toBodyMap: util.HashMap[String, Any] = {
+    val map = new util.HashMap[String, Any]()
+    map.put("path", outputPath)
+    if (delimiter.isDefined) map.put("delimiter", delimiter.get)
+    if (quote.isDefined) map.put("quote", quote.get)
+    if (escape.isDefined) map.put("escape", escape.get)
+    map.put("storage_format", storageFormat.getOrElse(HdfsStorageFormatType.CSV.toString))
+    map.put("overwrite", overwrite)
+    map
+  }
+}
+
+case class NotebookInputDBForExecution(executionLabel: String, tableName: String, schemaName: String, databaseName: String) extends NotebookIOForExecution {
+
+  def toBodyMap: util.HashMap[String, Any] = {
+    val map = new util.HashMap[String, Any]()
+    map.put("table_name", tableName)
+    map.put("schema_name", schemaName)
+    map.put("database_name", databaseName)
+    map
+  }
+}
+
+case class NotebookOutputDBForExecution(executionLabel: String, tableName: String, schemaName: String, databaseName: String, overwrite: Boolean) extends NotebookIOForExecution {
+
+  def toBodyMap: util.HashMap[String, Any] = {
+    val map = new util.HashMap[String, Any]()
+    map.put("table_name", tableName)
+    map.put("schema_name", schemaName)
+    map.put("database_name", databaseName)
+    map.put("overwrite", overwrite)
+    map
+  }
+}

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/OperatorGUINode.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/OperatorGUINode.scala
@@ -34,9 +34,11 @@ abstract class OperatorGUINode[I <: IOBase, O <: IOBase] {
     *                                  the nature of the output/input schemas.
     *                              E.g., provide the output schema.
     */
-  def onPlacement(operatorDialog: OperatorDialog,
-                  operatorDataSourceManager: OperatorDataSourceManager,
-                  operatorSchemaManager: OperatorSchemaManager): Unit
+  def onPlacement(
+    operatorDialog: OperatorDialog,
+    operatorDataSourceManager: OperatorDataSourceManager,
+    operatorSchemaManager: OperatorSchemaManager
+  ): Unit
 
   /**
     * Since Alpine 6.3, SDK 1.9.
@@ -81,9 +83,11 @@ abstract class OperatorGUINode[I <: IOBase, O <: IOBase] {
     *         The default implementation assumes that the connected inputs and/or
     *         parameters are valid.
     */
-  protected def onInputOrParameterChange(inputSchemas: Map[String, TabularSchema],
-                                         params: OperatorParameters,
-                                         operatorSchemaManager: OperatorSchemaManager): OperatorStatus = {
+  protected def onInputOrParameterChange(
+    inputSchemas: Map[String, TabularSchema],
+    params: OperatorParameters,
+    operatorSchemaManager: OperatorSchemaManager
+  ): OperatorStatus = {
     OperatorStatus(isValid = true, msg = None, EmptyIOMetadata())
   }
 
@@ -101,9 +105,11 @@ abstract class OperatorGUINode[I <: IOBase, O <: IOBase] {
     * @param visualFactory For creating visual models.
     * @return The visual model to be sent to the GUI for visualization.
     */
-  def onOutputVisualization(params: OperatorParameters,
-                            output: O,
-                            visualFactory: VisualModelFactory): VisualModel = {
+  def onOutputVisualization(
+    params: OperatorParameters,
+    output: O,
+    visualFactory: VisualModelFactory
+  ): VisualModel = {
     throw new NotImplementedError()
   }
 }

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/OperatorRuntime.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/OperatorRuntime.scala
@@ -33,11 +33,12 @@ O <: IOBase] {
     * @return The output from the execution.
     */
   @throws[Exception]
-  def onExecution(context: CTX,
-                  input: I,
-                  params: OperatorParameters,
-                  listener: OperatorListener
-                 ): O
+  def onExecution(
+    context: CTX,
+    input: I,
+    params: OperatorParameters,
+    listener: OperatorListener
+  ): O
 
   /**
     * This is called when the user clicks on 'stop'. If the operator is
@@ -49,9 +50,10 @@ O <: IOBase] {
     * @param listener The listener object to communicate information back to
     *                 the console.
     */
-  def onStop(context: CTX,
-             listener: OperatorListener
-            ): Unit
+  def onStop(
+    context: CTX,
+    listener: OperatorListener
+  ): Unit
 
   /**
     * This is called to generate the visual output for the results console.
@@ -66,11 +68,12 @@ O <: IOBase] {
     *                 the console.
     * @return
     */
-  def createVisualResults(context: CTX,
-                          input: I,
-                          output: O,
-                          params: OperatorParameters,
-                          listener: OperatorListener): VisualModel = {
+  def createVisualResults(
+    context: CTX,
+    input: I,
+    output: O,
+    params: OperatorParameters,
+    listener: OperatorListener): VisualModel = {
     throw new NotImplementedError()
   }
 

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/OperatorDialog.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/dialog/OperatorDialog.scala
@@ -156,9 +156,21 @@ trait OperatorDialog {
     * @param id              String id of dropdown box. This corresponds to the id for this parameter in OperatorsParameters.
     * @param label           The visual label of this dropdown box.
     * @param extensionFilter e.g. Seq(.pynb) for python notebooks
+    * @param isRequired      Whether the user is required to select a value for this parameter.
+    * @return A ChorusFileDropdown element.
     */
   def addChorusFileDropdownBox(id: String, label: String, extensionFilter: Set[String], isRequired: Boolean): ChorusFileDropdown
 
+  /**
+    * @param id              String id of dropdown box. This corresponds to the id for this parameter in OperatorsParameters.
+    * @param label           The visual label of this dropdown box.
+    * @param extensionFilter e.g. Seq(.pynb) for python notebooks
+    * @param isRequired      Whether the user is required to select a value for this parameter.
+    * @param linkText        If specified, a link button with label `textLink` will show up at the bottom right of the dropdown selector.
+    *                        Clicking on this button will open a new browser tab with URL of the workfile selected.
+    * @return A ChorusFileDropdown element.
+    */
+  def addChorusFileDropdownBox(id: String, label: String, extensionFilter: Set[String], isRequired: Boolean, linkText: Option[String]): ChorusFileDropdown
   /**
     * Add an integer text box.
     *
@@ -347,6 +359,23 @@ trait OperatorDialog {
                         regex: String,
                         required: Boolean
                        ): StringBox
+
+  /**
+    * Add a string box that obfuscates the characters typed.
+    * Note: In its current implementation, the passowrd cannot be seen in the UI, but is not in any
+    * other way more secure. The value of the password will still show up in a downloaded xml file.
+    *
+    * @param id       String id of this input box.
+    * @param label    The visual label of this input box.
+    * @param regex    The regular expression constraint for the input box. Default is "+." (any char)
+    * @param required Boolean indicating whether the value must be non-empty.
+    * @return
+    */
+  def addPasswordBox(id: String,
+    label: String,
+    regex: String,
+    required: Boolean): StringBox
+
 
   /**
     * Add a drop down box that can be used to select a parent operator name.

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/utils/ChorusAPICaller.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/utils/ChorusAPICaller.scala
@@ -2,10 +2,10 @@ package com.alpine.plugin.core.utils
 
 import java.io.{File, InputStream}
 
+import com.alpine.plugin.core._
 import com.alpine.plugin.core.dialog.ChorusFile
-import com.alpine.plugin.core.{NotebookDetails, PythonNotebookExecution, PythonNotebook}
 
-
+import scala.collection.immutable
 import scala.util.Try
 
 /**
@@ -68,12 +68,19 @@ abstract class ChorusAPICaller {
     * Runs a notebook by substituting the output path (and possibly input path(s)).
     * This will only work if the notebook attribute "ready_to_execute" is true.
     *
-    * @param notebook_id Id of the notebook to retrieve
-    * @param input_path1 input path to substitute to the path defined in the notebook
-    * @param outputPath  output path to substitute to the path defined in the notebook.
+    * @param notebook_id        Id of the notebook to retrieve
+    * @param dataSourceName     name of the data source where inputs come from and where output will be stored
+    * @param notebookInputs     Optional Seq[[NotebookIOForExecution]] of inputs info for substitution in the notebook
+    * @param notebookOutput     Optional [[NotebookIOForExecution]]  or single output substitution in the notebook
+    * @param sparkParametersMap Optional Spark parameters to be substituted in notebook if Spark is used (e.g Map("spark.executor.instances" -> "2")
     * @return
     */
-  def runNotebookExecution(notebook_id: String, input_path1: String, outputPath: String): Try[PythonNotebookExecution]
+  def runNotebookExecution(
+    notebook_id: String,
+    dataSourceName: String,
+    notebookInputs: Option[Seq[NotebookIOForExecution]],
+    notebookOutput: Option[NotebookIOForExecution],
+    sparkParametersMap: Option[immutable.Map[String, String]]): Try[PythonNotebookExecution]
 
   /**
     * Queries the status of the notebook execution.
@@ -84,5 +91,13 @@ abstract class ChorusAPICaller {
   def getNotebookExecutionStatus(notebook_id: String, execution_id: String): Try[PythonNotebookExecution]
 
   def createOrUpdateChorusFile(currentWorkflowID: String, file: File, overwrite: Boolean): Try[ChorusFile]
+
+  /**
+    * Lists the DB connection names (as registered in Chorus 'Data' tab) and ids for a specific workflow
+    *
+    * @param workfileID id of the current workflow
+    * @return The list of Chorus DB data sources [[ChorusDBSourceInfo]] the workflow is connected to.
+    */
+  def getWorkfileDBDataSources(workfileID: String): Try[List[ChorusDBSourceInfo]]
 
 }

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/utils/ChorusUtils.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/utils/ChorusUtils.scala
@@ -23,10 +23,12 @@ object ChorusUtils {
     * @param newVersionIfExists if set to true and the chorusFileName already exists, a new version will be created
     * @return either Success[ChorusFile] or a Failure with the error message
     */
-  def writeTextChorusFile(chorusFileName: String,
-                          text: String,
-                          context: ExecutionContext,
-                          newVersionIfExists: Boolean): Try[ChorusFile] = {
+  def writeTextChorusFile(
+    chorusFileName: String,
+    text: String,
+    context: ExecutionContext,
+    newVersionIfExists: Boolean
+  ): Try[ChorusFile] = {
 
     val currentWorkflowID = context.workflowInfo.workflowID
 

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/utils/OutputParameterUtils.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/utils/OutputParameterUtils.scala
@@ -82,7 +82,8 @@ trait OutputParameterUtils {
 }
 
 object OutputParameterUtils extends OutputParameterUtils {
-  def toTrueFalseString(bool : Boolean) : String = {
-    if(bool) trueStr else falseStr
+  @deprecated("Just use bool.toString")
+  def toTrueFalseString(bool: Boolean): String = {
+    bool.toString
   }
 }

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/utils/SparkParameterUtils.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/utils/SparkParameterUtils.scala
@@ -5,8 +5,9 @@
 package com.alpine.plugin.core.utils
 
 import com.alpine.plugin.core.OperatorParameters
-import com.alpine.plugin.core.dialog.OperatorDialog
-import com.alpine.plugin.core.dialog.SparkParameter
+import com.alpine.plugin.core.dialog.{OperatorDialog, SparkParameter}
+
+import scala.util.Try
 
 /**
   * Convenience functions for directly adding Spark related options to the
@@ -20,6 +21,8 @@ object SparkParameterUtils {
   val sparkNumExecutorCoresElementId = "spark_numExecutorCores"
   val storageLevelParamId = "spark_storage_level"
   val disableDynamicAllocationParamId = "noDynamicAllocation"
+  val numPartitionsId = "numPartitions"
+  val repartitionRDDId = "repartitionRDD"
 
   def addStandardSparkOptions(operatorDialog: OperatorDialog, additionalSparkParameters: List[SparkParameter]): Unit = {
     val list = List(
@@ -38,11 +41,11 @@ object SparkParameterUtils {
     "would like to maintain the old behavior use 'operatorDialog.addAdvancedSparkSettingsBox' directly" +
     "otherwise use signature without integer params")
   def addStandardSparkOptions(
-                               operatorDialog: OperatorDialog,
-                               defaultNumExecutors: Int,
-                               defaultExecutorMemoryMB: Int,
-                               defaultDriverMemoryMB: Int,
-                               defaultNumExecutorCores: Int, additionalSparkParameters: List[SparkParameter]) {
+    operatorDialog: OperatorDialog,
+    defaultNumExecutors: Int,
+    defaultExecutorMemoryMB: Int,
+    defaultDriverMemoryMB: Int,
+    defaultNumExecutorCores: Int, additionalSparkParameters: List[SparkParameter]) {
 
     addStandardSparkOptions(operatorDialog, additionalSparkParameters)
   }
@@ -51,11 +54,11 @@ object SparkParameterUtils {
     "would like to maintain the old behavior use 'operatorDialog.addAdvancedSparkSettingsBox' directly" +
     "otherwise use signature without integer params")
   def addStandardSparkOptions(
-                               operatorDialog: OperatorDialog,
-                               defaultNumExecutors: Int,
-                               defaultExecutorMemoryMB: Int,
-                               defaultDriverMemoryMB: Int,
-                               defaultNumExecutorCores: Int) {
+    operatorDialog: OperatorDialog,
+    defaultNumExecutors: Int,
+    defaultExecutorMemoryMB: Int,
+    defaultDriverMemoryMB: Int,
+    defaultNumExecutorCores: Int) {
 
     addStandardSparkOptions(operatorDialog, List[SparkParameter]())
   }
@@ -72,19 +75,83 @@ object SparkParameterUtils {
     * @param additionalSparkParameters - a list of a additional Spark Parameters.
     */
   def addStandardSparkOptionsWithStorageLevel(operatorDialog: OperatorDialog,
-                                              defaultNumExecutors: Int,
-                                              defaultExecutorMemoryMB: Int,
-                                              defaultDriverMemoryMB: Int,
-                                              defaultNumExecutorCores: Int,
-                                              defaultStorageLevel: String,
-                                              additionalSparkParameters: List[SparkParameter] =
-                                              List.empty[SparkParameter]) {
+    defaultNumExecutors: Int,
+    defaultExecutorMemoryMB: Int,
+    defaultDriverMemoryMB: Int,
+    defaultNumExecutorCores: Int,
+    defaultStorageLevel: String,
+    additionalSparkParameters: List[SparkParameter] =
+    List.empty[SparkParameter]) {
     val list = List(
-      SparkParameter(storageLevelParamId, "Storage Level", defaultStorageLevel, userSpecified = false, overridden = false))
+      makeStorageLevelParam(defaultStorageLevel))
     addStandardSparkOptions(operatorDialog, list ++ additionalSparkParameters)
   }
 
+  // =====================================================================================================
+  //  Additional Spark Parameters:
+  //  Add these parameters to the additionalSparkParameters list when using the "addStandardSparkOptions"
+  //  method. To create Specific Spark parameters with the same UI as those in the Alpine Core
+  // =====================================================================================================
+
+  /**
+    * Add storage level param. Default must be the string representation of a Spark Storage Level
+    * e.g. "MEMORY_AND_DISK"
+    *
+    * @param defaultStorageLevel
+    * @return
+    */
+  def makeStorageLevelParam(defaultStorageLevel: String): SparkParameter =
+    SparkParameter(storageLevelParamId, "Storage Level", defaultStorageLevel, userSpecified = false, overridden = false)
+
+  /**
+    * Create a "Repartition Data" checkbox to let the user determine whether the input data should
+    * be shuffled to increase the number of partitions.
+    */
+  def makeRepartitionParam: SparkParameter =
+    SparkParameter(repartitionRDDId, "Repartition Data", "", userSpecified = false, overridden = false)
+
+  /**
+    * Create a "Number of Partitions" parameter to let the user determine how many partitions should
+    * be used either when repartitioning the data (controlled by above param) or in when shuffling
+    * generally.
+    * If this parameter is not set, a value will be selected by auto tuning. If a value is selected
+    * this value will be used to set the "spark.default.parallelism" parameter which controls the
+    * default number of parameter used in a wide transformation in Spark.
+    *
+    * @return
+    */
+  def makeNumPartitionsParam: SparkParameter =
+    SparkParameter(numPartitionsId, "Number of Partitions", "", userSpecified = false, overridden = true)
+
+
+  /**
+    * Retrieve storage level param added via "makeStorageLevelParam" from advanced parameters box.
+    * Return NONE if the parameter was not added.
+    * NOTE: this method does not validate the String, so if the users put in an invalid storage
+    * level parameter, calling StorageLevel.fromString(s) on the result of this method will fail.
+    */
   def getStorageLevel(operatorParameters: OperatorParameters): Option[String] = {
     operatorParameters.getAdvancedSparkParameters.get(storageLevelParamId)
+  }
+
+  /**
+    * Return true if the repartition parameter was added AND the user checked it. Return false
+    * otherwise. Note that because this parameter is exposed as a check box by the alpine engine,
+    * the value of the parameter will be either "true" or "false" (string representation of java
+    * booleans).
+    **/
+
+  def getRepartition(operatorParameters: OperatorParameters): Boolean = {
+    operatorParameters.getAdvancedSparkParameters.getOrElse(repartitionRDDId, "false") == "true"
+  }
+
+  /**
+    * Retrieve the value of the number of partitions parameter added to the advanced spark box.
+    * However, the CO developer should be aware that Alpine Auto Tuning determines an optimal number
+    * of partitions to use and sets that value to spark.default.parallelism. So before repartitioning
+    * the developer should check that that is set if this method returns None.
+    */
+  def getUserSetNumPartitions(operatorParameters: OperatorParameters): Option[Int] = {
+    Try(operatorParameters.getAdvancedSparkParameters(storageLevelParamId).toInt).toOption
   }
 }

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/visualization/HDFSVisualModelHelper.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/visualization/HDFSVisualModelHelper.scala
@@ -20,6 +20,15 @@ trait HDFSVisualModelHelper {
   def createTabularDatasetVisualization(dataset: TabularDataset): TabularVisualModel
 
   /**
+    * Create a visualization for an Hdfs tabular dataset.
+    *
+    * @param dataset     A Hdfs tabular dataset that we want to visualize.
+    * @param rowsToFetch Number of rows to fetch.
+    * @return A visualization of the sample.
+    */
+  def createTabularDatasetVisualization(dataset: TabularDataset, rowsToFetch: Int): TabularVisualModel
+
+  /**
     * Gets the first few lines of the HdfsFile as plain text.
     * @param hdfsFile The file to preview.
     * @return The first few lines of the file as a visual model.

--- a/plugin-core/src/main/scala/com/alpine/plugin/core/visualization/VisualModelFactory.scala
+++ b/plugin-core/src/main/scala/com/alpine/plugin/core/visualization/VisualModelFactory.scala
@@ -1,6 +1,6 @@
 /**
- * COPYRIGHT (C) 2015 Alpine Data Labs Inc. All Rights Reserved.
- */
+  * COPYRIGHT (C) 2015 Alpine Data Labs Inc. All Rights Reserved.
+  */
 
 package com.alpine.plugin.core.visualization
 
@@ -15,51 +15,56 @@ import com.alpine.plugin.core.io.{DBTable, HdfsFile, IOBase, TabularDataset}
 @AlpineSdkApi
 trait VisualModelFactory {
   /**
-   * One can return a composite of multiple visualizations.
-   * @return A composite visual model that can contain multiple visualizations.
-   */
+    * One can return a composite of multiple visualizations.
+    *
+    * @return A composite visual model that can contain multiple visualizations.
+    */
   @deprecated("Use CompositeVisualModel directly instead.")
   def createCompositeVisualModel(): CompositeVisualModel
 
   /**
-   * Create the default visual model for the given IOBase object.
-   * This is useful to quickly generate a visual model for an existing IOBase
-   * object.
-   * @param ioObject The IOBase object that we want to create a visual model for.
-   * @return A matching visual model.
-   */
+    * Create the default visual model for the given IOBase object.
+    * This is useful to quickly generate a visual model for an existing IOBase
+    * object.
+    *
+    * @param ioObject The IOBase object that we want to create a visual model for.
+    * @return A matching visual model.
+    */
   def createDefaultVisualModel(ioObject: IOBase): VisualModel
 
   /**
-   * Create a simple text content visualization.
-   * @param text The text we want to display in the console.
-   * @return A text visualization object.
-   */
+    * Create a simple text content visualization.
+    *
+    * @param text The text we want to display in the console.
+    * @return A text visualization object.
+    */
   @deprecated("Use TextVisualModel directly instead.")
   def createTextVisualization(text: String): VisualModel
 
   /**
-   * Create a visualization for an Hdfs tabular dataset.
-   * @param dataset A Hdfs tabular dataset that we want to visualize.
-   * @return A visualization of the sample.
-   */
+    * Create a visualization for an Hdfs tabular dataset.
+    *
+    * @param dataset A Hdfs tabular dataset that we want to visualize.
+    * @return A visualization of the sample.
+    */
   def createTabularDatasetVisualization(dataset: TabularDataset): VisualModel
 
   /**
     * Gets the first few lines of the HdfsFile as plain text.
+    *
     * @param hdfsFile The file to preview.
     * @return The first few lines of the file as a visual model.
     */
   def createPlainTextVisualModel(hdfsFile: HdfsFile): TextVisualModel
 
   /**
-   * Create a visualization for a DB table.
+    * Create a visualization for a DB table.
     * This pulls a preview of the DB table, for display in the results console.
     * Equivalent to [[createDBTableVisualization(dbTable.schemaName, dbTable.tableName)]]
     *
-   * @param dbTable A DB table that we want to visualize.
-   * @return A visualization of the sample.
-   */
+    * @param dbTable A DB table that we want to visualize.
+    * @return A visualization of the sample.
+    */
   def createDBTableVisualization(dbTable: DBTable): VisualModel
 
   /**
@@ -73,12 +78,13 @@ trait VisualModelFactory {
   def createDBTableVisualization(schemaName: String, tableName: String): VisualModel
 
   /**
-   * Create a visualization of an HTML text element.
-   * Use this method rather than the 'createTextVisualization' method if you want to include
-   * HTML formatting elements (like a table, or bold text) in your visualization.
-   * @param text An HTML String
-   * @return A text visualization object, which puts the html text inside of a <text> tag.
-   */
+    * Create a visualization of an HTML text element.
+    * Use this method rather than the 'createTextVisualization' method if you want to include
+    * HTML formatting elements (like a table, or bold text) in your visualization.
+    *
+    * @param text An HTML String
+    * @return A text visualization object, which puts the html text inside of a <text> tag.
+    */
   @deprecated("Use HtmlVisualModel directly instead.")
   def createHtmlTextVisualization(text: String): VisualModel
 

--- a/plugin-model/src/main/scala/com/alpine/plugin/model/ModelWrapper.scala
+++ b/plugin-model/src/main/scala/com/alpine/plugin/model/ModelWrapper.scala
@@ -6,7 +6,7 @@ package com.alpine.plugin.model
 
 import com.alpine.model._
 import com.alpine.plugin.core.annotation.AlpineSdkApi
-import com.alpine.plugin.core.io.{IOBase, OperatorInfo}
+import com.alpine.plugin.core.io.IOBase
 
 /**
  * :: AlpineSdkApi ::
@@ -26,18 +26,7 @@ abstract class ModelWrapper[M <: MLModel](
 class ClassificationModelWrapper(
   model: ClassificationRowModel,
   override val addendum: Map[String, AnyRef] = Map[String, AnyRef]()
-) extends ModelWrapper[ClassificationRowModel](model, addendum) {
-
-  @deprecated("Use constructor without sourceOperatorInfo and modelName.")
-  def this(modelName: String,
-           model: ClassificationRowModel,
-           sourceOperatorInfo: Option[OperatorInfo],
-           addendum: Map[String, AnyRef] = Map[String, AnyRef]()) = {
-    this(model, addendum)
-  }
-
-}
-
+) extends ModelWrapper[ClassificationRowModel](model, addendum)
 /**
  * :: AlpineSdkApi ::
  * A wrapper around objects that implement the Alpine Clustering Model APIs.
@@ -46,17 +35,7 @@ class ClassificationModelWrapper(
 class ClusteringModelWrapper(
   override val model: ClusteringRowModel,
   override val addendum: Map[String, AnyRef] = Map[String, AnyRef]()
-) extends ModelWrapper[ClusteringRowModel](model, addendum) {
-
-  @deprecated("Use constructor without sourceOperatorInfo and modelName.")
-  def this(modelName: String,
-           model: ClusteringRowModel,
-           sourceOperatorInfo: Option[OperatorInfo],
-           addendum: Map[String, AnyRef] = Map[String, AnyRef]()) = {
-    this(model, addendum)
-  }
-
-}
+) extends ModelWrapper[ClusteringRowModel](model, addendum)
 
 /**
  * :: AlpineSdkApi ::
@@ -66,17 +45,7 @@ class ClusteringModelWrapper(
 class RegressionModelWrapper(
   model: RegressionRowModel,
   override val addendum: Map[String, AnyRef] = Map[String, AnyRef]()
-) extends ModelWrapper[RegressionRowModel](model, addendum) {
-
-  @deprecated("Use constructor without sourceOperatorInfo and modelName.")
-  def this(modelName: String,
-           model: RegressionRowModel,
-           sourceOperatorInfo: Option[OperatorInfo],
-           addendum: Map[String, AnyRef] = Map[String, AnyRef]()) = {
-    this(model, addendum)
-  }
-
-}
+) extends ModelWrapper[RegressionRowModel](model, addendum)
 
 /**
  * :: AlpineSdkApi ::
@@ -86,14 +55,4 @@ class RegressionModelWrapper(
 class TransformerWrapper(
   model: RowModel,
   override val addendum: Map[String, AnyRef] = Map[String, AnyRef]()
-) extends ModelWrapper[RowModel](model, addendum) {
-
-  @deprecated("Use constructor without sourceOperatorInfo and modelName.")
-  def this(modelName: String,
-           model: RowModel,
-           sourceOperatorInfo: Option[OperatorInfo],
-           addendum: Map[String, AnyRef] = Map[String, AnyRef]()) = {
-    this(model, addendum)
-  }
-
-}
+) extends ModelWrapper[RowModel](model, addendum)

--- a/plugin-spark/src/main/scala/com/alpine/plugin/core/spark/SparkExecutionContext.scala
+++ b/plugin-spark/src/main/scala/com/alpine/plugin/core/spark/SparkExecutionContext.scala
@@ -6,13 +6,14 @@ package com.alpine.plugin.core.spark
 
 import java.io.{InputStream, OutputStream}
 
-import org.apache.hadoop.fs.FileSystem
-
-import scala.concurrent.Future
 import com.alpine.plugin.core.annotation.AlpineSdkApi
-import com.alpine.plugin.core.{ExecutionContext, OperatorListener, OperatorParameters}
 import com.alpine.plugin.core.io.IOBase
 import com.alpine.plugin.core.visualization.HDFSVisualModelHelper
+import com.alpine.plugin.core.{ExecutionContext, OperatorListener, OperatorParameters}
+import org.apache.hadoop.fs.FileSystem
+
+import scala.collection.immutable
+import scala.concurrent.Future
 
 /**
   * :: AlpineSdkApi ::
@@ -48,12 +49,13 @@ trait SparkExecutionContext extends ExecutionContext {
     * @tparam JOB The job type.
     * @return A submitted job object.
     */
-  def submitJob[I <: IOBase, O <: IOBase, JOB <: SparkIOTypedPluginJob[I, O]](jobClass: Class[JOB],
-                                                                              input: I,
-                                                                              params: OperatorParameters,
-                                                                              sparkConf: SparkJobConfiguration,
-                                                                              listener: OperatorListener
-                                                                             ): SubmittedSparkJob[O]
+  def submitJob[I <: IOBase, O <: IOBase, JOB <: SparkIOTypedPluginJob[I, O]](
+    jobClass: Class[JOB],
+    input: I,
+    params: OperatorParameters,
+    sparkConf: SparkJobConfiguration,
+    listener: OperatorListener
+  ): SubmittedSparkJob[O]
 
   def doHdfsAction[T](fs: FileSystem => T): T
 
@@ -109,4 +111,30 @@ trait SparkExecutionContext extends ExecutionContext {
   def mkdir(path: String): Boolean
 
   def visualModelHelper: HDFSVisualModelHelper
+
+  /**
+    * Returns the map of Spark parameters after autoTuning algorithm is applied.
+    * This is the final set of Spark properties ready to be passed with Spark job submission (except spark.job.name)
+    * It leverages:
+    * - user-defined Spark properties at the operator level (Spark Advanced Settings box), workflow level
+    * and data source level (in this order of precedence).
+    * - AutoTunerOptions set in the SparkJobConfiguration (@param sparkConf)
+    * - auto-tuned parameters that were not user-specified
+    *
+    * @param jobClass  IO typed job class.
+    * @param input     Input to the job. This automatically gets serialized.
+    * @param params    Parameters into the job.
+    * @param sparkConf Spark job configuration.
+    * @param listener  Listener to pass to the job. The spark job should be
+    *                  able to communicate directly with Alpine as it's running.
+    * @tparam I Input type.
+    * @return The map of relevant Spark properties after auto tuning algorithm was applied.
+    */
+  def getSparkAutoTunedParameters[I <: IOBase, JOB <: SparkIOTypedPluginJob[I, _]](
+    jobClass: Class[JOB],
+    input: I,
+    params: OperatorParameters,
+    sparkConf: SparkJobConfiguration,
+    listener: OperatorListener
+  ): immutable.Map[String, String]
 }

--- a/plugin-test/src/main/scala/com/alpine/plugin/test/mock/ChorusAPICallerMock.scala
+++ b/plugin-test/src/main/scala/com/alpine/plugin/test/mock/ChorusAPICallerMock.scala
@@ -4,7 +4,7 @@ import java.io.{File, FileInputStream, InputStream}
 
 import com.alpine.plugin.core.dialog.ChorusFile
 import com.alpine.plugin.core.utils.ChorusAPICaller
-import com.alpine.plugin.core.{NotebookDetails, PythonNotebook, PythonNotebookExecution}
+import com.alpine.plugin.core.{ChorusDBSourceInfo, NotebookDetails, PythonNotebook, PythonNotebookExecution}
 
 import scala.util.Try
 
@@ -42,6 +42,7 @@ class ChorusAPICallerMock(val workfiles: Seq[ChorusFileInWorkspaceMock]) extends
   override def readWorkfileAsText(workfile: ChorusFile): Try[String] = {
     readWorkfileAsText(workfile.id)
   }
+
   /**
     * Runs a workfile and returns the workfile object if successful
     * Note: this will not fail if the workfile exists but cannot be run (e.g. if the notebook server
@@ -56,11 +57,18 @@ class ChorusAPICallerMock(val workfiles: Seq[ChorusFileInWorkspaceMock]) extends
 
   override def getNotebookDetails(notebookID: String): Try[NotebookDetails] = ???
 
-  override def runNotebookExecution(notebook_id: String, input_path1: String, outputPath: String): Try[PythonNotebookExecution] = ???
+  override def runNotebookExecution(
+    notebook_id: String,
+    dataSourceName: String,
+    notebookInputs: Option[Seq[com.alpine.plugin.core.NotebookIOForExecution]],
+    notebookOutput: Option[com.alpine.plugin.core.NotebookIOForExecution],
+    sparkParametersMap: Option[scala.collection.immutable.Map[String, String]]): Try[PythonNotebookExecution] = ???
 
   override def getNotebookExecutionStatus(notebook_id: String, execution_id: String): Try[PythonNotebookExecution] = ???
 
   override def createOrUpdateChorusFile(workspaceId: String, file: File, overwrite: Boolean): Try[ChorusFile] = ???
+
+  override def getWorkfileDBDataSources(workfileID: String): Try[List[ChorusDBSourceInfo]] = ???
 
 }
 

--- a/plugin-test/src/main/scala/com/alpine/plugin/test/mock/HDFSVisualModelHelperMock.scala
+++ b/plugin-test/src/main/scala/com/alpine/plugin/test/mock/HDFSVisualModelHelperMock.scala
@@ -17,6 +17,10 @@ class HDFSVisualModelHelperMock extends HDFSVisualModelHelper {
     TabularVisualModel(Seq(), dataset.tabularSchema.definedColumns)
   }
 
+  override def createTabularDatasetVisualization(dataset: TabularDataset, rowsToFetch: Int): TabularVisualModel = {
+    TabularVisualModel(Seq(), dataset.tabularSchema.definedColumns)
+  }
+
   override def createPlainTextVisualModel(hdfsFile: HdfsFile): TextVisualModel = {
     TextVisualModel("In the production environment, this would be replaced with a preview of the contents of the file at "
       + hdfsFile.path + " on the hadoop cluster.")

--- a/plugin-test/src/main/scala/com/alpine/plugin/test/mock/OperatorParametersMock.java
+++ b/plugin-test/src/main/scala/com/alpine/plugin/test/mock/OperatorParametersMock.java
@@ -4,18 +4,17 @@
 
 package com.alpine.plugin.test.mock;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashMap;
-
+import com.alpine.plugin.core.OperatorParameters;
 import com.alpine.plugin.core.dialog.ChorusFile;
 import com.alpine.plugin.core.io.OperatorInfo;
 import scala.Option;
 import scala.Tuple2;
 import scala.collection.JavaConversions;
-
-import com.alpine.plugin.core.OperatorParameters;
 import scala.collection.mutable.Map;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
 
 /**
  * Plugin 1.0 operator parameters.

--- a/plugin-test/src/main/scala/com/alpine/plugin/test/mock/SparkExecutionContextMock.scala
+++ b/plugin-test/src/main/scala/com/alpine/plugin/test/mock/SparkExecutionContextMock.scala
@@ -6,11 +6,11 @@ package com.alpine.plugin.test.mock
 import java.io.{File, InputStream, OutputStream}
 
 import com.alpine.plugin.core.config.CustomOperatorConfig
-import com.alpine.plugin.core.{ChorusUserInfo, OperatorListener, OperatorParameters, WorkflowInfo}
 import com.alpine.plugin.core.io.IOBase
 import com.alpine.plugin.core.spark.{SparkExecutionContext, SparkIOTypedPluginJob, SparkJobConfiguration, SubmittedSparkJob}
 import com.alpine.plugin.core.utils.ChorusAPICaller
 import com.alpine.plugin.core.visualization.HDFSVisualModelHelper
+import com.alpine.plugin.core.{ChorusUserInfo, OperatorListener, OperatorParameters, WorkflowInfo}
 import org.apache.hadoop.fs.FileSystem
 
 /**
@@ -49,4 +49,11 @@ class SparkExecutionContextMock(chorusAPICallerMock: ChorusAPICaller) extends Sp
   override def recommendedTempDir: File = ???
 
   override def config: CustomOperatorConfig = ???
+
+  override def getSparkAutoTunedParameters[I <: IOBase, JOB <: SparkIOTypedPluginJob[I, _]](
+    jobClass: Class[JOB],
+    input: I,
+    params: OperatorParameters,
+    sparkConf: SparkJobConfiguration,
+    listener: OperatorListener) = ???
 }

--- a/plugin-test/src/main/scala/com/alpine/plugin/test/utils/SimpleAbstractSparkJobSuite.scala
+++ b/plugin-test/src/main/scala/com/alpine/plugin/test/utils/SimpleAbstractSparkJobSuite.scala
@@ -81,7 +81,7 @@ class SimpleAbstractSparkJobSuite extends FunSuite {
                                                         inputParameters: OperatorParametersMock,
                                                         tabularSchema: Option[TabularSchema],
                                                         dataSourceName: String = "dataSource"): OperatorParametersMock = {
-    val operatorDialogMock = new OperatorDialogMock(inputParameters, input, tabularSchema)
+    val operatorDialogMock = OperatorDialogMock(inputParameters, input)
     operatorGUINode.onPlacement(operatorDialogMock,
       OperatorDataSourceManagerMock(dataSourceName),
       new OperatorSchemaManagerMock())
@@ -92,8 +92,7 @@ class SimpleAbstractSparkJobSuite extends FunSuite {
                                                                inputHdfs: HdfsTabularDataset,
                                                                inputParameters: OperatorParametersMock,
                                                                dataSourceName: String = "dataSource"): OperatorParametersMock = {
-    val operatorDialogMock = new OperatorDialogMock(inputParameters,
-      inputHdfs, Some(inputHdfs.tabularSchema))
+    val operatorDialogMock = new OperatorDialogMock(inputParameters, inputHdfs)
     testGUI.onPlacement(operatorDialogMock,
       OperatorDataSourceManagerMock(dataSourceName),
       new OperatorSchemaManagerMock())


### PR DESCRIPTION
@rachelwarren @emiliedelongueau ?

It looks like the main changes are:
-- Improving SQL performance for models (using string builders instead of recursive calls, reducing repeated bad data evaluation for One hot encoding).
-- Adding code to convert Abstract Syntax Tree models (ASTModel) back into SQL.
-- Some preparatory work for Scala 2.11, such as removing conflicting contructors.
-- Chorus API / Python notebook stuff
-- Autotuning / Repartition improvements
-- Password box